### PR TITLE
Comments should match until end of line

### DIFF
--- a/grammar/fbp.peg
+++ b/grammar/fbp.peg
@@ -126,7 +126,7 @@ port
   = portname:[A-Z.0-9]+ __ {return portname.join("").toLowerCase()}
 
 anychar
-  = [a-zA-Z0-9 .,#:{}@+?!^=()_\-$*/\\\[\]{}\"&`%\|]
+  = [^\n\r\u2028\u2029]
 
 iipchar
   = [\\]['] { return "'"; }

--- a/lib/fbp.js
+++ b/lib/fbp.js
@@ -920,13 +920,13 @@ module.exports = (function(){
       function parse_anychar() {
         var result0;
         
-        if (/^[a-zA-Z0-9 .,#:{}@+?!^=()_\-$*\/\\[\]{}"&`%|]/.test(input.charAt(pos))) {
+        if (/^[^\n\r\u2028\u2029]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
         } else {
           result0 = null;
           if (reportFailures === 0) {
-            matchFailed("[a-zA-Z0-9 .,#:{}@+?!^=()_\\-$*\\/\\\\[\\]{}\"&`%|]");
+            matchFailed("[^\\n\\r\\u2028\\u2029]");
           }
         }
         return result0;


### PR DESCRIPTION
I'm curious as there may be a reason I'm not aware of as to why a specific character class for matching `anychar` is used. `anychar` is used only for comments and comments should be matched until the end of line.
