### PR TITLE
Support anonymous nodes, default ports, JSON IIPs, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 /browser/
 /spec/*.js
+/spec/result.xml

--- a/grammar/fbp.peg
+++ b/grammar/fbp.peg
@@ -6,6 +6,8 @@
 {
   var parser, edges, nodes;
 
+  var defaultInPort = "IN", defaultOutPort = "OUT";
+
   parser = this;
   delete parser.exports;
   delete parser.inports;
@@ -161,7 +163,13 @@
   }
 
   function makePort(process, port, defaultPort) {
-    var p = { process: process, port: port ? port.port : defaultPort };
+    if (!options.caseSensitive) {
+      defaultPort = defaultPort.toLowerCase()
+    }
+    var p = {
+        process: process,
+        port: port ? port.port : defaultPort
+    };
     if (port && port.index != null) {
         p.index = port.index;
     }
@@ -169,10 +177,10 @@
 }
 
   function makeInPort(process, port) {
-      return makePort(process, port, "IN");
+      return makePort(process, port, defaultInPort);
   }
   function makeOutPort(process, port) {
-      return makePort(process, port, "OUT");
+      return makePort(process, port, defaultOutPort);
   }
 }
 
@@ -183,6 +191,8 @@ line
   = _ "EXPORT=" priv:portName ":" pub:portName _ LineTerminator? {return parser.registerExports(priv,pub)}
   / _ "INPORT=" node:node "." port:portName ":" pub:portName _ LineTerminator? {return parser.registerInports(node,port,pub)}
   / _ "OUTPORT=" node:node "." port:portName ":" pub:portName _ LineTerminator? {return parser.registerOutports(node,port,pub)}
+  / _ "DEFAULT_INPORT=" name:portName _ LineTerminator? { defaultInPort = name}
+  / _ "DEFAULT_OUTPORT=" name:portName _ LineTerminator? { defaultOutPort = name}
   / comment [\n\r\u2028\u2029]?
   / _ [\n\r\u2028\u2029]
   / _ edges:connection _ LineTerminator? {return parser.registerEdges(edges);}
@@ -211,12 +221,10 @@ bridge
   / x:(port__)? proc:nodeWithComponent y:(__port)?  { return [{"tgt":makeInPort(proc, x)},{"src":makeOutPort(proc, y)}]; }
 
 outport
-  = proc:node port:__port { return {"src":makeOutPort(proc, port)} }
-  / proc:nodeWithComponent port:(__port)? { return {"src":makeOutPort(proc, port)} }
+  = proc:node port:(__port)? { return {"src":makeOutPort(proc, port)} }
 
 inport
-  = port:port__ proc:node  { return {"tgt":makeInPort(proc, port)} }
-  / port:(port__)? proc:nodeWithComponent  { return {"tgt":makeInPort(proc, port)} }
+  = port:(port__)? proc:node  { return {"tgt":makeInPort(proc, port)} }
 
 iip
   = "'" iip:(iipchar)* "'"        { return {"data":iip.join("")} }

--- a/grammar/fbp.peg
+++ b/grammar/fbp.peg
@@ -41,6 +41,18 @@
 
   }
 
+  var anonymousIndexes = {};
+  var anonymousNodeNames = {};
+  parser.addAnonymousNode = function(comp, offset) {
+      if (!anonymousNodeNames[offset]) {
+          var componentName = comp.comp.replace(/[^a-zA-Z0-9]+/, "_");
+          anonymousIndexes[componentName] = (anonymousIndexes[componentName] || 0) + 1;
+          anonymousNodeNames[offset] = "_" + componentName + "_" + anonymousIndexes[componentName];
+          this.addNode(anonymousNodeNames[offset], comp);
+      }
+      return anonymousNodeNames[offset];
+  }
+
   parser.getResult = function () {
     var result = {
       processes: nodes,
@@ -201,7 +213,18 @@ inport
   = port:port _ proc:node  { return {"tgt":makePort(proc, port.port, port.index)} }
 
 node
-  = node:([a-zA-Z_][a-zA-Z0-9_\-]*) comp:component? { if(comp){parser.addNode(makeName(node),comp);}; return makeName(node)}
+  = name:nodeNameAndComponent { return name}
+  / name:nodeName { return name}
+  / name:nodeComponent { return name}
+
+nodeName
+  = name:([a-zA-Z_][a-zA-Z0-9_\-]*) { return makeName(name)}
+
+nodeNameAndComponent
+  = name:nodeName comp:component { parser.addNode(name,comp); return name}
+
+nodeComponent
+  = comp:component { return parser.addAnonymousNode(comp, location().start.offset) }
 
 component
   = "(" comp:([a-zA-Z/\-0-9_]*)? meta:compMeta? ")" { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; }

--- a/grammar/fbp.peg
+++ b/grammar/fbp.peg
@@ -145,14 +145,14 @@
     flats = flatten(parser.edges);
     grouped = [];
     var current = {};
-    flats.forEach(function (o, i) {
-      if (i % 2 !== 0) {
-        var pair = grouped[grouped.length - 1];
-        pair.tgt = o.tgt;
-        return;
-      }
-      grouped.push(o);
-    });
+    for (var i = 1; i < flats.length; i += 1) {
+        // skip over default ports at the beginning of lines (could also handle this in grammar)
+        if (("src" in flats[i - 1] || "data" in flats[i - 1]) && "tgt" in flats[i]) {
+            flats[i - 1].tgt = flats[i].tgt;
+            grouped.push(flats[i - 1]);
+            i++;
+        }
+    }
     return grouped;
   }
 
@@ -207,17 +207,20 @@ destination
   / bridge
 
 bridge
-  = x:port _ proc:node _ y:port  { return [{"tgt":makeInPort(proc, x)},{"src":makeOutPort(proc, y)}]; }
+  = x:port__ proc:node y:__port  { return [{"tgt":makeInPort(proc, x)},{"src":makeOutPort(proc, y)}]; }
+  / x:(port__)? proc:nodeWithComponent y:(__port)?  { return [{"tgt":makeInPort(proc, x)},{"src":makeOutPort(proc, y)}]; }
 
 outport
-  = proc:node _ port:port  { return {"src":makeOutPort(proc, port)} }
+  = proc:node port:__port { return {"src":makeOutPort(proc, port)} }
+  / proc:nodeWithComponent port:(__port)? { return {"src":makeOutPort(proc, port)} }
+
+inport
+  = port:port__ proc:node  { return {"tgt":makeInPort(proc, port)} }
+  / port:(port__)? proc:nodeWithComponent  { return {"tgt":makeInPort(proc, port)} }
 
 iip
   = "'" iip:(iipchar)* "'"        { return {"data":iip.join("")} }
   / iip:JSON_text  { return {"data":iip} }
-
-inport
-  = port:port _ proc:node  { return {"tgt":makeInPort(proc, port)} }
 
 node
   = name:nodeNameAndComponent { return name}
@@ -233,20 +236,30 @@ nodeNameAndComponent
 nodeComponent
   = comp:component { return parser.addAnonymousNode(comp, location().start.offset) }
 
+nodeWithComponent
+  = nodeNameAndComponent
+  / nodeComponent
+
 component
   = "(" comp:([a-zA-Z/\-0-9_]*)? meta:compMeta? ")" { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; }
 
 compMeta
   = ":" meta:[a-zA-Z/=_,0-9]+  {return meta}
 
-portIndex
-  = "[" portindex:[0-9]+ "]" {return parseInt(portindex.join(''))}
-
 port
-  = portname:portName portindex:(portIndex)?  __ {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }}
+  = portname:portName portindex:(portIndex)? {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }}
+
+port__
+  = port:port __ { return port; }
+
+__port
+  = __ port:port { return port; }
 
 portName
   = portname:([a-zA-Z_][a-zA-Z.0-9_]*) {return makeName(portname)}
+
+portIndex
+  = "[" portindex:[0-9]+ "]" {return parseInt(portindex.join(''))}
 
 anychar
   = [^\n\r\u2028\u2029]

--- a/grammar/fbp.peg
+++ b/grammar/fbp.peg
@@ -191,6 +191,7 @@ outport
 
 iip
   = "'" iip:(iipchar)* "'"        { return {"data":iip.join("")} }
+  / iip:JSON_text  { return {"data":iip} }
 
 inport 
   = port:port _ proc:node  { return {"tgt":{process:proc, port:port}} } 
@@ -226,3 +227,136 @@ _
 
 __
   = " "+
+
+/*
+ * JSON Grammar
+ * ============
+ *
+ * Based on the grammar from RFC 7159 [1].
+ *
+ * Note that JSON is also specified in ECMA-262 [2], ECMA-404 [3], and on the
+ * JSON website [4] (somewhat informally). The RFC seems the most authoritative
+ * source, which is confirmed e.g. by [5].
+ *
+ * [1] http://tools.ietf.org/html/rfc7159
+ * [2] http://www.ecma-international.org/publications/standards/Ecma-262.htm
+ * [3] http://www.ecma-international.org/publications/standards/Ecma-404.htm
+ * [4] http://json.org/
+ * [5] https://www.tbray.org/ongoing/When/201x/2014/03/05/RFC7159-JSON
+ */
+
+/* ----- 2. JSON Grammar ----- */
+
+JSON_text
+    = ws value:value ws { return value; }
+
+begin_array     = ws "[" ws
+begin_object    = ws "{" ws
+end_array       = ws "]" ws
+end_object      = ws "}" ws
+name_separator  = ws ":" ws
+value_separator = ws "," ws
+
+ws "whitespace" = [ \t\n\r]*
+
+/* ----- 3. Values ----- */
+
+value
+    = false
+    / null
+    / true
+    / object
+    / array
+    / number
+    / string
+
+false = "false" { return false; }
+null  = "null"  { return null;  }
+true  = "true"  { return true;  }
+
+/* ----- 4. Objects ----- */
+
+object
+    = begin_object
+      members:(
+        head:member
+        tail:(value_separator m:member { return m; })*
+        {
+          var result = {}, i;
+
+          result[head.name] = head.value;
+
+          for (i = 0; i < tail.length; i++) {
+            result[tail[i].name] = tail[i].value;
+          }
+
+          return result;
+        }
+      )?
+      end_object
+      { return members !== null ? members: {}; }
+
+member
+    = name:string name_separator value:value {
+        return { name: name, value: value };
+      }
+
+/* ----- 5. Arrays ----- */
+
+array
+    = begin_array
+      values:(
+        head:value
+        tail:(value_separator v:value { return v; })*
+        { return [head].concat(tail); }
+      )?
+      end_array
+      { return values !== null ? values : []; }
+
+/* ----- 6. Numbers ----- */
+
+number "number"
+    = minus? int frac? exp? { return parseFloat(text()); }
+
+decimal_point = "."
+digit1_9      = [1-9]
+e             = [eE]
+exp           = e (minus / plus)? DIGIT+
+frac          = decimal_point DIGIT+
+int           = zero / (digit1_9 DIGIT*)
+minus         = "-"
+plus          = "+"
+zero          = "0"
+
+/* ----- 7. Strings ----- */
+
+string "string"
+    = quotation_mark chars:char* quotation_mark { return chars.join(""); }
+
+char
+    = unescaped
+    / escape
+      sequence:(
+          '"'
+        / "\\"
+        / "/"
+        / "b" { return "\b"; }
+        / "f" { return "\f"; }
+        / "n" { return "\n"; }
+        / "r" { return "\r"; }
+        / "t" { return "\t"; }
+        / "u" digits:$(HEXDIG HEXDIG HEXDIG HEXDIG) {
+            return String.fromCharCode(parseInt(digits, 16));
+          }
+      )
+      { return sequence; }
+
+escape         = "\\"
+quotation_mark = '"'
+unescaped      = [^\0-\x1F\x22\x5C]
+
+/* ----- Core ABNF Rules ----- */
+
+/* See RFC 4234, Appendix B (http://tools.ietf.org/html/rfc4627). */
+DIGIT  = [0-9]
+HEXDIG = [0-9a-f]i

--- a/grammar/fbp.peg
+++ b/grammar/fbp.peg
@@ -4,7 +4,7 @@
  */
 
 {
-  var parser, edges, nodes; 
+  var parser, edges, nodes;
 
   parser = this;
   delete parser.exports;
@@ -38,7 +38,7 @@
       }
       nodes[nodeName].metadata=metadata;
     }
-   
+
   }
 
   parser.getResult = function () {
@@ -64,7 +64,7 @@
     }
     result.caseSensitive = options.caseSensitive;
     return result;
-  }  
+  }
 
   var flatten = function (array, isShallow) {
     var index = -1,
@@ -83,7 +83,7 @@
     }
     return result;
   }
-  
+
   parser.registerExports = function (priv, pub) {
     if (!parser.exports) {
       parser.exports = [];
@@ -126,15 +126,15 @@
     edges.forEach(function (o, i) {
       parser.edges.push(o);
     });
-  }  
+  }
 
-  parser.processEdges = function () {   
+  parser.processEdges = function () {
     var flats, grouped;
     flats = flatten(parser.edges);
     grouped = [];
     var current = {};
     flats.forEach(function (o, i) {
-      if (i % 2 !== 0) { 
+      if (i % 2 !== 0) {
         var pair = grouped[grouped.length - 1];
         pair.tgt = o.tgt;
         return;
@@ -147,15 +147,23 @@
   function makeName(s) {
     return s[0] + s[1].join("");
   }
+
+  function makePort(process, port, index) {
+    var p = { process: process, port: port };
+    if (index != null) {
+        p.index = index;
+    }
+    return p;
+  }
 }
 
 start
   = (line)*  { return parser.getResult();  }
 
 line
-  = _ "EXPORT=" priv:basePort ":" pub:basePort _ LineTerminator? {return parser.registerExports(priv,pub)}
-  / _ "INPORT=" node:node "." port:basePort ":" pub:basePort _ LineTerminator? {return parser.registerInports(node,port,pub)}
-  / _ "OUTPORT=" node:node "." port:basePort ":" pub:basePort _ LineTerminator? {return parser.registerOutports(node,port,pub)}
+  = _ "EXPORT=" priv:portName ":" pub:portName _ LineTerminator? {return parser.registerExports(priv,pub)}
+  / _ "INPORT=" node:node "." port:portName ":" pub:portName _ LineTerminator? {return parser.registerInports(node,port,pub)}
+  / _ "OUTPORT=" node:node "." port:portName ":" pub:portName _ LineTerminator? {return parser.registerOutports(node,port,pub)}
   / comment [\n\r\u2028\u2029]?
   / _ [\n\r\u2028\u2029]
   / _ edges:connection _ LineTerminator? {return parser.registerEdges(edges);}
@@ -166,7 +174,7 @@ LineTerminator
 comment
   = _ "#" (anychar)*
 
-connection 
+connection
   = x:source _ "->" _ y:connection { return [x,y]; }
   / destination
 
@@ -180,22 +188,17 @@ destination
   / bridge
 
 bridge
-  = x:port _ proc:node _ y:port           { return [{"tgt":{process:proc, port:x}},{"src":{process:proc, port:y}}]; }
-  / x:portWithIndex _ proc:node _ y:port  { return [{"tgt":{process:proc, port:x.port, index:x.index}},{"src":{process:proc, port:y}}]; }
-  / x:port _ proc:node _ y:portWithIndex  { return [{"tgt":{process:proc, port:x}},{"src":{process:proc, port:y.port, index:y.index}}]; }
-  / x:portWithIndex _ proc:node _ y:portWithIndex  { return [{"tgt":{process:proc, port:x.port, index:x.index}},{"src":{process:proc, port:y.port, index:y.index}}]; }
+  = x:port _ proc:node _ y:port  { return [{"tgt":makePort(proc, x.port, x.index)},{"src":makePort(proc, y.port, y.index)}]; }
 
 outport
-  = proc:node _ port:port  { return {"src":{process:proc, port:port}} }  
-  / proc:node _ port:portWithIndex  { return {"src":{process:proc, port:port.port, index: port.index}} }
+  = proc:node _ port:port  { return {"src":makePort(proc, port.port, port.index)} }
 
 iip
   = "'" iip:(iipchar)* "'"        { return {"data":iip.join("")} }
   / iip:JSON_text  { return {"data":iip} }
 
-inport 
-  = port:port _ proc:node  { return {"tgt":{process:proc, port:port}} } 
-  / port:portWithIndex _ proc:node  { return {"tgt":{process:proc, port:port.port, index: port.index}} }
+inport
+  = port:port _ proc:node  { return {"tgt":makePort(proc, port.port, port.index)} }
 
 node
   = node:([a-zA-Z_][a-zA-Z0-9_\-]*) comp:component? { if(comp){parser.addNode(makeName(node),comp);}; return makeName(node)}
@@ -203,16 +206,16 @@ node
 component
   = "(" comp:([a-zA-Z/\-0-9_]*)? meta:compMeta? ")" { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; }
 
-compMeta 
+compMeta
   = ":" meta:[a-zA-Z/=_,0-9]+  {return meta}
 
+portIndex
+  = "[" portindex:[0-9]+ "]" {return parseInt(portindex.join(''))}
+
 port
-  = portname:basePort __ {return options.caseSensitive ? portname : portname.toLowerCase()}
+  = portname:portName portindex:(portIndex)?  __ {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }}
 
-portWithIndex
-  = portname:basePort "[" portindex:[0-9]+ "]"  __ {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: parseInt(portindex.join('')) }}
-
-basePort
+portName
   = portname:([a-zA-Z_][a-zA-Z.0-9_]*) {return makeName(portname)}
 
 anychar

--- a/grammar/fbp.peg
+++ b/grammar/fbp.peg
@@ -160,12 +160,19 @@
     return s[0] + s[1].join("");
   }
 
-  function makePort(process, port, index) {
-    var p = { process: process, port: port };
-    if (index != null) {
-        p.index = index;
+  function makePort(process, port, defaultPort) {
+    var p = { process: process, port: port ? port.port : defaultPort };
+    if (port && port.index != null) {
+        p.index = port.index;
     }
     return p;
+}
+
+  function makeInPort(process, port) {
+      return makePort(process, port, "IN");
+  }
+  function makeOutPort(process, port) {
+      return makePort(process, port, "OUT");
   }
 }
 
@@ -200,17 +207,17 @@ destination
   / bridge
 
 bridge
-  = x:port _ proc:node _ y:port  { return [{"tgt":makePort(proc, x.port, x.index)},{"src":makePort(proc, y.port, y.index)}]; }
+  = x:port _ proc:node _ y:port  { return [{"tgt":makeInPort(proc, x)},{"src":makeOutPort(proc, y)}]; }
 
 outport
-  = proc:node _ port:port  { return {"src":makePort(proc, port.port, port.index)} }
+  = proc:node _ port:port  { return {"src":makeOutPort(proc, port)} }
 
 iip
   = "'" iip:(iipchar)* "'"        { return {"data":iip.join("")} }
   / iip:JSON_text  { return {"data":iip} }
 
 inport
-  = port:port _ proc:node  { return {"tgt":makePort(proc, port.port, port.index)} }
+  = port:port _ proc:node  { return {"tgt":makeInPort(proc, port)} }
 
 node
   = name:nodeNameAndComponent { return name}

--- a/grammar/fbp.peg
+++ b/grammar/fbp.peg
@@ -136,10 +136,11 @@
   }
 
   parser.registerEdges = function (edges) {
-
-    edges.forEach(function (o, i) {
-      parser.edges.push(o);
-    });
+    if (Array.isArray(edges)) {
+      edges.forEach(function (o, i) {
+        parser.edges.push(o);
+      });
+    }
   }
 
   parser.processEdges = function () {

--- a/lib/fbp.js
+++ b/lib/fbp.js
@@ -69,45 +69,127 @@ module.exports = (function() {
         peg$c30 = "'",
         peg$c31 = { type: "literal", value: "'", description: "\"'\"" },
         peg$c32 = function(iip) { return {"data":iip.join("")} },
-        peg$c33 = function(port, proc) { return {"tgt":{process:proc, port:port}} },
-        peg$c34 = function(port, proc) { return {"tgt":{process:proc, port:port.port, index: port.index}} },
-        peg$c35 = /^[a-zA-Z_]/,
-        peg$c36 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
-        peg$c37 = /^[a-zA-Z0-9_\-]/,
-        peg$c38 = { type: "class", value: "[a-zA-Z0-9_\\-]", description: "[a-zA-Z0-9_\\-]" },
-        peg$c39 = function(node, comp) { if(comp){parser.addNode(makeName(node),comp);}; return makeName(node)},
-        peg$c40 = "(",
-        peg$c41 = { type: "literal", value: "(", description: "\"(\"" },
-        peg$c42 = /^[a-zA-Z\/\-0-9_]/,
-        peg$c43 = { type: "class", value: "[a-zA-Z/\\-0-9_]", description: "[a-zA-Z/\\-0-9_]" },
-        peg$c44 = ")",
-        peg$c45 = { type: "literal", value: ")", description: "\")\"" },
-        peg$c46 = function(comp, meta) { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; },
-        peg$c47 = /^[a-zA-Z\/=_,0-9]/,
-        peg$c48 = { type: "class", value: "[a-zA-Z/=_,0-9]", description: "[a-zA-Z/=_,0-9]" },
-        peg$c49 = function(meta) {return meta},
-        peg$c50 = function(portname) {return options.caseSensitive ? portname : portname.toLowerCase()},
-        peg$c51 = "[",
-        peg$c52 = { type: "literal", value: "[", description: "\"[\"" },
-        peg$c53 = /^[0-9]/,
-        peg$c54 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c55 = "]",
-        peg$c56 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c57 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: parseInt(portindex.join('')) }},
-        peg$c58 = /^[a-zA-Z.0-9_]/,
-        peg$c59 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
-        peg$c60 = function(portname) {return makeName(portname)},
-        peg$c61 = /^[^\n\r\u2028\u2029]/,
-        peg$c62 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
-        peg$c63 = /^[\\]/,
-        peg$c64 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
-        peg$c65 = /^[']/,
-        peg$c66 = { type: "class", value: "[']", description: "[']" },
-        peg$c67 = function() { return "'"; },
-        peg$c68 = /^[^']/,
-        peg$c69 = { type: "class", value: "[^']", description: "[^']" },
-        peg$c70 = " ",
-        peg$c71 = { type: "literal", value: " ", description: "\" \"" },
+        peg$c33 = function(iip) { return {"data":iip} },
+        peg$c34 = function(port, proc) { return {"tgt":{process:proc, port:port}} },
+        peg$c35 = function(port, proc) { return {"tgt":{process:proc, port:port.port, index: port.index}} },
+        peg$c36 = /^[a-zA-Z_]/,
+        peg$c37 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
+        peg$c38 = /^[a-zA-Z0-9_\-]/,
+        peg$c39 = { type: "class", value: "[a-zA-Z0-9_\\-]", description: "[a-zA-Z0-9_\\-]" },
+        peg$c40 = function(node, comp) { if(comp){parser.addNode(makeName(node),comp);}; return makeName(node)},
+        peg$c41 = "(",
+        peg$c42 = { type: "literal", value: "(", description: "\"(\"" },
+        peg$c43 = /^[a-zA-Z\/\-0-9_]/,
+        peg$c44 = { type: "class", value: "[a-zA-Z/\\-0-9_]", description: "[a-zA-Z/\\-0-9_]" },
+        peg$c45 = ")",
+        peg$c46 = { type: "literal", value: ")", description: "\")\"" },
+        peg$c47 = function(comp, meta) { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; },
+        peg$c48 = /^[a-zA-Z\/=_,0-9]/,
+        peg$c49 = { type: "class", value: "[a-zA-Z/=_,0-9]", description: "[a-zA-Z/=_,0-9]" },
+        peg$c50 = function(meta) {return meta},
+        peg$c51 = function(portname) {return options.caseSensitive ? portname : portname.toLowerCase()},
+        peg$c52 = "[",
+        peg$c53 = { type: "literal", value: "[", description: "\"[\"" },
+        peg$c54 = /^[0-9]/,
+        peg$c55 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c56 = "]",
+        peg$c57 = { type: "literal", value: "]", description: "\"]\"" },
+        peg$c58 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: parseInt(portindex.join('')) }},
+        peg$c59 = /^[a-zA-Z.0-9_]/,
+        peg$c60 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
+        peg$c61 = function(portname) {return makeName(portname)},
+        peg$c62 = /^[^\n\r\u2028\u2029]/,
+        peg$c63 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
+        peg$c64 = /^[\\]/,
+        peg$c65 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
+        peg$c66 = /^[']/,
+        peg$c67 = { type: "class", value: "[']", description: "[']" },
+        peg$c68 = function() { return "'"; },
+        peg$c69 = /^[^']/,
+        peg$c70 = { type: "class", value: "[^']", description: "[^']" },
+        peg$c71 = " ",
+        peg$c72 = { type: "literal", value: " ", description: "\" \"" },
+        peg$c73 = function(value) { return value; },
+        peg$c74 = "{",
+        peg$c75 = { type: "literal", value: "{", description: "\"{\"" },
+        peg$c76 = "}",
+        peg$c77 = { type: "literal", value: "}", description: "\"}\"" },
+        peg$c78 = { type: "other", description: "whitespace" },
+        peg$c79 = /^[ \t\n\r]/,
+        peg$c80 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+        peg$c81 = "false",
+        peg$c82 = { type: "literal", value: "false", description: "\"false\"" },
+        peg$c83 = function() { return false; },
+        peg$c84 = "null",
+        peg$c85 = { type: "literal", value: "null", description: "\"null\"" },
+        peg$c86 = function() { return null;  },
+        peg$c87 = "true",
+        peg$c88 = { type: "literal", value: "true", description: "\"true\"" },
+        peg$c89 = function() { return true;  },
+        peg$c90 = function(head, m) { return m; },
+        peg$c91 = function(head, tail) {
+                  var result = {}, i;
+
+                  result[head.name] = head.value;
+
+                  for (i = 0; i < tail.length; i++) {
+                    result[tail[i].name] = tail[i].value;
+                  }
+
+                  return result;
+                },
+        peg$c92 = function(members) { return members !== null ? members: {}; },
+        peg$c93 = function(name, value) {
+                return { name: name, value: value };
+              },
+        peg$c94 = function(head, v) { return v; },
+        peg$c95 = function(head, tail) { return [head].concat(tail); },
+        peg$c96 = function(values) { return values !== null ? values : []; },
+        peg$c97 = { type: "other", description: "number" },
+        peg$c98 = function() { return parseFloat(text()); },
+        peg$c99 = /^[1-9]/,
+        peg$c100 = { type: "class", value: "[1-9]", description: "[1-9]" },
+        peg$c101 = /^[eE]/,
+        peg$c102 = { type: "class", value: "[eE]", description: "[eE]" },
+        peg$c103 = "-",
+        peg$c104 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c105 = "+",
+        peg$c106 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c107 = "0",
+        peg$c108 = { type: "literal", value: "0", description: "\"0\"" },
+        peg$c109 = { type: "other", description: "string" },
+        peg$c110 = function(chars) { return chars.join(""); },
+        peg$c111 = "\"",
+        peg$c112 = { type: "literal", value: "\"", description: "\"\\\"\"" },
+        peg$c113 = "\\",
+        peg$c114 = { type: "literal", value: "\\", description: "\"\\\\\"" },
+        peg$c115 = "/",
+        peg$c116 = { type: "literal", value: "/", description: "\"/\"" },
+        peg$c117 = "b",
+        peg$c118 = { type: "literal", value: "b", description: "\"b\"" },
+        peg$c119 = function() { return "\b"; },
+        peg$c120 = "f",
+        peg$c121 = { type: "literal", value: "f", description: "\"f\"" },
+        peg$c122 = function() { return "\f"; },
+        peg$c123 = "n",
+        peg$c124 = { type: "literal", value: "n", description: "\"n\"" },
+        peg$c125 = function() { return "\n"; },
+        peg$c126 = "r",
+        peg$c127 = { type: "literal", value: "r", description: "\"r\"" },
+        peg$c128 = function() { return "\r"; },
+        peg$c129 = "t",
+        peg$c130 = { type: "literal", value: "t", description: "\"t\"" },
+        peg$c131 = function() { return "\t"; },
+        peg$c132 = "u",
+        peg$c133 = { type: "literal", value: "u", description: "\"u\"" },
+        peg$c134 = function(digits) {
+                    return String.fromCharCode(parseInt(digits, 16));
+                  },
+        peg$c135 = function(sequence) { return sequence; },
+        peg$c136 = /^[^\0-\x1F"\\]/,
+        peg$c137 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
+        peg$c138 = /^[0-9a-f]/i,
+        peg$c139 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -1038,6 +1120,15 @@ module.exports = (function() {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseJSON_text();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c33(s1);
+        }
+        s0 = s1;
+      }
 
       return s0;
     }
@@ -1053,7 +1144,7 @@ module.exports = (function() {
           s3 = peg$parsenode();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c33(s1, s3);
+            s1 = peg$c34(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1076,7 +1167,7 @@ module.exports = (function() {
             s3 = peg$parsenode();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c34(s1, s3);
+              s1 = peg$c35(s1, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1100,30 +1191,30 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (peg$c35.test(input.charAt(peg$currPos))) {
+      if (peg$c36.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c36); }
+        if (peg$silentFails === 0) { peg$fail(peg$c37); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c37.test(input.charAt(peg$currPos))) {
+        if (peg$c38.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c38); }
+          if (peg$silentFails === 0) { peg$fail(peg$c39); }
         }
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          if (peg$c37.test(input.charAt(peg$currPos))) {
+          if (peg$c38.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c38); }
+            if (peg$silentFails === 0) { peg$fail(peg$c39); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -1144,7 +1235,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c39(s1, s2);
+          s1 = peg$c40(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1163,29 +1254,29 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c40;
+        s1 = peg$c41;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c41); }
+        if (peg$silentFails === 0) { peg$fail(peg$c42); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c42.test(input.charAt(peg$currPos))) {
+        if (peg$c43.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c43); }
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
         }
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c42.test(input.charAt(peg$currPos))) {
+          if (peg$c43.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c43); }
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
           }
         }
         if (s2 === peg$FAILED) {
@@ -1198,15 +1289,15 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s4 = peg$c44;
+              s4 = peg$c45;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c45); }
+              if (peg$silentFails === 0) { peg$fail(peg$c46); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c46(s2, s3);
+              s1 = peg$c47(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1241,22 +1332,22 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c47.test(input.charAt(peg$currPos))) {
+        if (peg$c48.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c48); }
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c47.test(input.charAt(peg$currPos))) {
+            if (peg$c48.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c48); }
+              if (peg$silentFails === 0) { peg$fail(peg$c49); }
             }
           }
         } else {
@@ -1264,7 +1355,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c49(s2);
+          s1 = peg$c50(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1287,7 +1378,7 @@ module.exports = (function() {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c50(s1);
+          s1 = peg$c51(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1308,30 +1399,30 @@ module.exports = (function() {
       s1 = peg$parsebasePort();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c51;
+          s2 = peg$c52;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c52); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c53.test(input.charAt(peg$currPos))) {
+          if (peg$c54.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
+            if (peg$silentFails === 0) { peg$fail(peg$c55); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c53.test(input.charAt(peg$currPos))) {
+              if (peg$c54.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                if (peg$silentFails === 0) { peg$fail(peg$c55); }
               }
             }
           } else {
@@ -1339,17 +1430,17 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c55;
+              s4 = peg$c56;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c56); }
+              if (peg$silentFails === 0) { peg$fail(peg$c57); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse__();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c57(s1, s3);
+                s1 = peg$c58(s1, s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1380,30 +1471,30 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (peg$c35.test(input.charAt(peg$currPos))) {
+      if (peg$c36.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c36); }
+        if (peg$silentFails === 0) { peg$fail(peg$c37); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c58.test(input.charAt(peg$currPos))) {
+        if (peg$c59.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c59); }
+          if (peg$silentFails === 0) { peg$fail(peg$c60); }
         }
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          if (peg$c58.test(input.charAt(peg$currPos))) {
+          if (peg$c59.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c59); }
+            if (peg$silentFails === 0) { peg$fail(peg$c60); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -1419,7 +1510,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c60(s1);
+        s1 = peg$c61(s1);
       }
       s0 = s1;
 
@@ -1429,12 +1520,12 @@ module.exports = (function() {
     function peg$parseanychar() {
       var s0;
 
-      if (peg$c61.test(input.charAt(peg$currPos))) {
+      if (peg$c62.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c62); }
+        if (peg$silentFails === 0) { peg$fail(peg$c63); }
       }
 
       return s0;
@@ -1444,24 +1535,24 @@ module.exports = (function() {
       var s0, s1, s2;
 
       s0 = peg$currPos;
-      if (peg$c63.test(input.charAt(peg$currPos))) {
+      if (peg$c64.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+        if (peg$silentFails === 0) { peg$fail(peg$c65); }
       }
       if (s1 !== peg$FAILED) {
-        if (peg$c65.test(input.charAt(peg$currPos))) {
+        if (peg$c66.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c67); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c67();
+          s1 = peg$c68();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1472,12 +1563,12 @@ module.exports = (function() {
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
-        if (peg$c68.test(input.charAt(peg$currPos))) {
+        if (peg$c69.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+          if (peg$silentFails === 0) { peg$fail(peg$c70); }
         }
       }
 
@@ -1489,20 +1580,20 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c70;
+        s1 = peg$c71;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c71); }
+        if (peg$silentFails === 0) { peg$fail(peg$c72); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
         if (input.charCodeAt(peg$currPos) === 32) {
-          s1 = peg$c70;
+          s1 = peg$c71;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c71); }
+          if (peg$silentFails === 0) { peg$fail(peg$c72); }
         }
       }
       if (s0 === peg$FAILED) {
@@ -1517,25 +1608,1097 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c70;
+        s1 = peg$c71;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c71); }
+        if (peg$silentFails === 0) { peg$fail(peg$c72); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
           if (input.charCodeAt(peg$currPos) === 32) {
-            s1 = peg$c70;
+            s1 = peg$c71;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c71); }
+            if (peg$silentFails === 0) { peg$fail(peg$c72); }
           }
         }
       } else {
         s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parseJSON_text() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsews();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsevalue();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsews();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c73(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsebegin_array() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsews();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 91) {
+          s2 = peg$c52;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsews();
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsebegin_object() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsews();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 123) {
+          s2 = peg$c74;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c75); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsews();
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parseend_array() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsews();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 93) {
+          s2 = peg$c56;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsews();
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parseend_object() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsews();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 125) {
+          s2 = peg$c76;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c77); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsews();
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsename_separator() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsews();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s2 = peg$c3;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c4); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsews();
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsevalue_separator() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsews();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s2 = peg$c17;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c18); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsews();
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsews() {
+      var s0, s1;
+
+      peg$silentFails++;
+      s0 = [];
+      if (peg$c79.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      }
+      while (s1 !== peg$FAILED) {
+        s0.push(s1);
+        if (peg$c79.test(input.charAt(peg$currPos))) {
+          s1 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+        }
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsevalue() {
+      var s0;
+
+      s0 = peg$parsefalse();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parsenull();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parsetrue();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseobject();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parsearray();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parsenumber();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parsestring();
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return s0;
+    }
+
+    function peg$parsefalse() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c81) {
+        s1 = peg$c81;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c83();
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parsenull() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4) === peg$c84) {
+        s1 = peg$c84;
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c86();
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parsetrue() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4) === peg$c87) {
+        s1 = peg$c87;
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c88); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c89();
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parseobject() {
+      var s0, s1, s2, s3, s4, s5, s6, s7;
+
+      s0 = peg$currPos;
+      s1 = peg$parsebegin_object();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        s3 = peg$parsemember();
+        if (s3 !== peg$FAILED) {
+          s4 = [];
+          s5 = peg$currPos;
+          s6 = peg$parsevalue_separator();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parsemember();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s5;
+              s6 = peg$c90(s3, s7);
+              s5 = s6;
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+          while (s5 !== peg$FAILED) {
+            s4.push(s5);
+            s5 = peg$currPos;
+            s6 = peg$parsevalue_separator();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parsemember();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s5;
+                s6 = peg$c90(s3, s7);
+                s5 = s6;
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s2;
+            s3 = peg$c91(s3, s4);
+            s2 = s3;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+        if (s2 === peg$FAILED) {
+          s2 = null;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseend_object();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c92(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsemember() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsestring();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsename_separator();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsevalue();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c93(s1, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsearray() {
+      var s0, s1, s2, s3, s4, s5, s6, s7;
+
+      s0 = peg$currPos;
+      s1 = peg$parsebegin_array();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        s3 = peg$parsevalue();
+        if (s3 !== peg$FAILED) {
+          s4 = [];
+          s5 = peg$currPos;
+          s6 = peg$parsevalue_separator();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parsevalue();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s5;
+              s6 = peg$c94(s3, s7);
+              s5 = s6;
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+          while (s5 !== peg$FAILED) {
+            s4.push(s5);
+            s5 = peg$currPos;
+            s6 = peg$parsevalue_separator();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parsevalue();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s5;
+                s6 = peg$c94(s3, s7);
+                s5 = s6;
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s2;
+            s3 = peg$c95(s3, s4);
+            s2 = s3;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+        if (s2 === peg$FAILED) {
+          s2 = null;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseend_array();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c96(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsenumber() {
+      var s0, s1, s2, s3, s4;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      s1 = peg$parseminus();
+      if (s1 === peg$FAILED) {
+        s1 = null;
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseint();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsefrac();
+          if (s3 === peg$FAILED) {
+            s3 = null;
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parseexp();
+            if (s4 === peg$FAILED) {
+              s4 = null;
+            }
+            if (s4 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c98();
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsedecimal_point() {
+      var s0;
+
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s0 = peg$c8;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsedigit1_9() {
+      var s0;
+
+      if (peg$c99.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsee() {
+      var s0;
+
+      if (peg$c101.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+      }
+
+      return s0;
+    }
+
+    function peg$parseexp() {
+      var s0, s1, s2, s3, s4;
+
+      s0 = peg$currPos;
+      s1 = peg$parsee();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseminus();
+        if (s2 === peg$FAILED) {
+          s2 = peg$parseplus();
+        }
+        if (s2 === peg$FAILED) {
+          s2 = null;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = [];
+          s4 = peg$parseDIGIT();
+          if (s4 !== peg$FAILED) {
+            while (s4 !== peg$FAILED) {
+              s3.push(s4);
+              s4 = peg$parseDIGIT();
+            }
+          } else {
+            s3 = peg$FAILED;
+          }
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsefrac() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parsedecimal_point();
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parseDIGIT();
+        if (s3 !== peg$FAILED) {
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$parseDIGIT();
+          }
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parseint() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$parsezero();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsedigit1_9();
+        if (s1 !== peg$FAILED) {
+          s2 = [];
+          s3 = peg$parseDIGIT();
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$parseDIGIT();
+          }
+          if (s2 !== peg$FAILED) {
+            s1 = [s1, s2];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
+
+      return s0;
+    }
+
+    function peg$parseminus() {
+      var s0;
+
+      if (input.charCodeAt(peg$currPos) === 45) {
+        s0 = peg$c103;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c104); }
+      }
+
+      return s0;
+    }
+
+    function peg$parseplus() {
+      var s0;
+
+      if (input.charCodeAt(peg$currPos) === 43) {
+        s0 = peg$c105;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsezero() {
+      var s0;
+
+      if (input.charCodeAt(peg$currPos) === 48) {
+        s0 = peg$c107;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c108); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsestring() {
+      var s0, s1, s2, s3;
+
+      peg$silentFails++;
+      s0 = peg$currPos;
+      s1 = peg$parsequotation_mark();
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parsechar();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parsechar();
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsequotation_mark();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c110(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      peg$silentFails--;
+      if (s0 === peg$FAILED) {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsechar() {
+      var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+      s0 = peg$parseunescaped();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseescape();
+        if (s1 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 34) {
+            s2 = peg$c111;
+            peg$currPos++;
+          } else {
+            s2 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c112); }
+          }
+          if (s2 === peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 92) {
+              s2 = peg$c113;
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c114); }
+            }
+            if (s2 === peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 47) {
+                s2 = peg$c115;
+                peg$currPos++;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c116); }
+              }
+              if (s2 === peg$FAILED) {
+                s2 = peg$currPos;
+                if (input.charCodeAt(peg$currPos) === 98) {
+                  s3 = peg$c117;
+                  peg$currPos++;
+                } else {
+                  s3 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c118); }
+                }
+                if (s3 !== peg$FAILED) {
+                  peg$savedPos = s2;
+                  s3 = peg$c119();
+                }
+                s2 = s3;
+                if (s2 === peg$FAILED) {
+                  s2 = peg$currPos;
+                  if (input.charCodeAt(peg$currPos) === 102) {
+                    s3 = peg$c120;
+                    peg$currPos++;
+                  } else {
+                    s3 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                  }
+                  if (s3 !== peg$FAILED) {
+                    peg$savedPos = s2;
+                    s3 = peg$c122();
+                  }
+                  s2 = s3;
+                  if (s2 === peg$FAILED) {
+                    s2 = peg$currPos;
+                    if (input.charCodeAt(peg$currPos) === 110) {
+                      s3 = peg$c123;
+                      peg$currPos++;
+                    } else {
+                      s3 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c124); }
+                    }
+                    if (s3 !== peg$FAILED) {
+                      peg$savedPos = s2;
+                      s3 = peg$c125();
+                    }
+                    s2 = s3;
+                    if (s2 === peg$FAILED) {
+                      s2 = peg$currPos;
+                      if (input.charCodeAt(peg$currPos) === 114) {
+                        s3 = peg$c126;
+                        peg$currPos++;
+                      } else {
+                        s3 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c127); }
+                      }
+                      if (s3 !== peg$FAILED) {
+                        peg$savedPos = s2;
+                        s3 = peg$c128();
+                      }
+                      s2 = s3;
+                      if (s2 === peg$FAILED) {
+                        s2 = peg$currPos;
+                        if (input.charCodeAt(peg$currPos) === 116) {
+                          s3 = peg$c129;
+                          peg$currPos++;
+                        } else {
+                          s3 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c130); }
+                        }
+                        if (s3 !== peg$FAILED) {
+                          peg$savedPos = s2;
+                          s3 = peg$c131();
+                        }
+                        s2 = s3;
+                        if (s2 === peg$FAILED) {
+                          s2 = peg$currPos;
+                          if (input.charCodeAt(peg$currPos) === 117) {
+                            s3 = peg$c132;
+                            peg$currPos++;
+                          } else {
+                            s3 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                          }
+                          if (s3 !== peg$FAILED) {
+                            s4 = peg$currPos;
+                            s5 = peg$currPos;
+                            s6 = peg$parseHEXDIG();
+                            if (s6 !== peg$FAILED) {
+                              s7 = peg$parseHEXDIG();
+                              if (s7 !== peg$FAILED) {
+                                s8 = peg$parseHEXDIG();
+                                if (s8 !== peg$FAILED) {
+                                  s9 = peg$parseHEXDIG();
+                                  if (s9 !== peg$FAILED) {
+                                    s6 = [s6, s7, s8, s9];
+                                    s5 = s6;
+                                  } else {
+                                    peg$currPos = s5;
+                                    s5 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s5;
+                                  s5 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s5;
+                                s5 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s5;
+                              s5 = peg$FAILED;
+                            }
+                            if (s5 !== peg$FAILED) {
+                              s4 = input.substring(s4, peg$currPos);
+                            } else {
+                              s4 = s5;
+                            }
+                            if (s4 !== peg$FAILED) {
+                              peg$savedPos = s2;
+                              s3 = peg$c134(s4);
+                              s2 = s3;
+                            } else {
+                              peg$currPos = s2;
+                              s2 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s2;
+                            s2 = peg$FAILED;
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c135(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
+
+      return s0;
+    }
+
+    function peg$parseescape() {
+      var s0;
+
+      if (input.charCodeAt(peg$currPos) === 92) {
+        s0 = peg$c113;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
+      }
+
+      return s0;
+    }
+
+    function peg$parsequotation_mark() {
+      var s0;
+
+      if (input.charCodeAt(peg$currPos) === 34) {
+        s0 = peg$c111;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c112); }
+      }
+
+      return s0;
+    }
+
+    function peg$parseunescaped() {
+      var s0;
+
+      if (peg$c136.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c137); }
+      }
+
+      return s0;
+    }
+
+    function peg$parseDIGIT() {
+      var s0;
+
+      if (peg$c54.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+      }
+
+      return s0;
+    }
+
+    function peg$parseHEXDIG() {
+      var s0;
+
+      if (peg$c138.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c139); }
       }
 
       return s0;
@@ -1580,7 +2743,28 @@ module.exports = (function() {
       }
 
       parser.getResult = function () {
-        return {processes:nodes, connections:parser.processEdges(), exports:parser.exports, inports: parser.inports, outports: parser.outports, caseSensitive: options.caseSensitive};
+        var result = {
+          processes: nodes,
+          connections: parser.processEdges(),
+          exports: parser.exports,
+          inports: parser.inports,
+          outports: parser.outports
+        };
+
+        var validateSchema = parser.validateSchema; // default
+        if (typeof(options.validateSchema) !== 'undefined') { validateSchema = options.validateSchema; } // explicit option
+        if (validateSchema) {
+          if (typeof(tv4) === 'undefined') {
+            var tv4 = require("tv4");
+          }
+          var schema = require("../schema/graph.json");
+          var validation = tv4.validateMultiple(result, schema);
+          if (!validation.valid) {
+            throw new Error("fbp: Did not validate againt graph schema:\n" + JSON.stringify(validation.errors, null, 2));
+          }
+        }
+        result.caseSensitive = options.caseSensitive;
+        return result;
       }  
 
       var flatten = function (array, isShallow) {

--- a/lib/fbp.js
+++ b/lib/fbp.js
@@ -60,74 +60,69 @@ module.exports = (function() {
         peg$c21 = "->",
         peg$c22 = { type: "literal", value: "->", description: "\"->\"" },
         peg$c23 = function(x, y) { return [x,y]; },
-        peg$c24 = function(x, proc, y) { return [{"tgt":{process:proc, port:x}},{"src":{process:proc, port:y}}]; },
-        peg$c25 = function(x, proc, y) { return [{"tgt":{process:proc, port:x.port, index:x.index}},{"src":{process:proc, port:y}}]; },
-        peg$c26 = function(x, proc, y) { return [{"tgt":{process:proc, port:x}},{"src":{process:proc, port:y.port, index:y.index}}]; },
-        peg$c27 = function(x, proc, y) { return [{"tgt":{process:proc, port:x.port, index:x.index}},{"src":{process:proc, port:y.port, index:y.index}}]; },
-        peg$c28 = function(proc, port) { return {"src":{process:proc, port:port}} },
-        peg$c29 = function(proc, port) { return {"src":{process:proc, port:port.port, index: port.index}} },
-        peg$c30 = "'",
-        peg$c31 = { type: "literal", value: "'", description: "\"'\"" },
-        peg$c32 = function(iip) { return {"data":iip.join("")} },
-        peg$c33 = function(iip) { return {"data":iip} },
-        peg$c34 = function(port, proc) { return {"tgt":{process:proc, port:port}} },
-        peg$c35 = function(port, proc) { return {"tgt":{process:proc, port:port.port, index: port.index}} },
-        peg$c36 = /^[a-zA-Z_]/,
-        peg$c37 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
-        peg$c38 = /^[a-zA-Z0-9_\-]/,
-        peg$c39 = { type: "class", value: "[a-zA-Z0-9_\\-]", description: "[a-zA-Z0-9_\\-]" },
-        peg$c40 = function(node, comp) { if(comp){parser.addNode(makeName(node),comp);}; return makeName(node)},
-        peg$c41 = "(",
-        peg$c42 = { type: "literal", value: "(", description: "\"(\"" },
-        peg$c43 = /^[a-zA-Z\/\-0-9_]/,
-        peg$c44 = { type: "class", value: "[a-zA-Z/\\-0-9_]", description: "[a-zA-Z/\\-0-9_]" },
-        peg$c45 = ")",
-        peg$c46 = { type: "literal", value: ")", description: "\")\"" },
-        peg$c47 = function(comp, meta) { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; },
-        peg$c48 = /^[a-zA-Z\/=_,0-9]/,
-        peg$c49 = { type: "class", value: "[a-zA-Z/=_,0-9]", description: "[a-zA-Z/=_,0-9]" },
-        peg$c50 = function(meta) {return meta},
-        peg$c51 = function(portname) {return options.caseSensitive ? portname : portname.toLowerCase()},
-        peg$c52 = "[",
-        peg$c53 = { type: "literal", value: "[", description: "\"[\"" },
-        peg$c54 = /^[0-9]/,
-        peg$c55 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c56 = "]",
-        peg$c57 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c58 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: parseInt(portindex.join('')) }},
-        peg$c59 = /^[a-zA-Z.0-9_]/,
-        peg$c60 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
-        peg$c61 = function(portname) {return makeName(portname)},
-        peg$c62 = /^[^\n\r\u2028\u2029]/,
-        peg$c63 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
-        peg$c64 = /^[\\]/,
-        peg$c65 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
-        peg$c66 = /^[']/,
-        peg$c67 = { type: "class", value: "[']", description: "[']" },
-        peg$c68 = function() { return "'"; },
-        peg$c69 = /^[^']/,
-        peg$c70 = { type: "class", value: "[^']", description: "[^']" },
-        peg$c71 = " ",
-        peg$c72 = { type: "literal", value: " ", description: "\" \"" },
-        peg$c73 = function(value) { return value; },
-        peg$c74 = "{",
-        peg$c75 = { type: "literal", value: "{", description: "\"{\"" },
-        peg$c76 = "}",
-        peg$c77 = { type: "literal", value: "}", description: "\"}\"" },
-        peg$c78 = { type: "other", description: "whitespace" },
-        peg$c79 = /^[ \t\n\r]/,
-        peg$c80 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
-        peg$c81 = "false",
-        peg$c82 = { type: "literal", value: "false", description: "\"false\"" },
-        peg$c83 = function() { return false; },
-        peg$c84 = "null",
-        peg$c85 = { type: "literal", value: "null", description: "\"null\"" },
-        peg$c86 = function() { return null;  },
-        peg$c87 = "true",
-        peg$c88 = { type: "literal", value: "true", description: "\"true\"" },
-        peg$c89 = function() { return true;  },
-        peg$c90 = function(head, m) { return m; },
-        peg$c91 = function(head, tail) {
+        peg$c24 = function(x, proc, y) { return [{"tgt":makePort(proc, x.port, x.index)},{"src":makePort(proc, y.port, y.index)}]; },
+        peg$c25 = function(proc, port) { return {"src":makePort(proc, port.port, port.index)} },
+        peg$c26 = "'",
+        peg$c27 = { type: "literal", value: "'", description: "\"'\"" },
+        peg$c28 = function(iip) { return {"data":iip.join("")} },
+        peg$c29 = function(iip) { return {"data":iip} },
+        peg$c30 = function(port, proc) { return {"tgt":makePort(proc, port.port, port.index)} },
+        peg$c31 = /^[a-zA-Z_]/,
+        peg$c32 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
+        peg$c33 = /^[a-zA-Z0-9_\-]/,
+        peg$c34 = { type: "class", value: "[a-zA-Z0-9_\\-]", description: "[a-zA-Z0-9_\\-]" },
+        peg$c35 = function(node, comp) { if(comp){parser.addNode(makeName(node),comp);}; return makeName(node)},
+        peg$c36 = "(",
+        peg$c37 = { type: "literal", value: "(", description: "\"(\"" },
+        peg$c38 = /^[a-zA-Z\/\-0-9_]/,
+        peg$c39 = { type: "class", value: "[a-zA-Z/\\-0-9_]", description: "[a-zA-Z/\\-0-9_]" },
+        peg$c40 = ")",
+        peg$c41 = { type: "literal", value: ")", description: "\")\"" },
+        peg$c42 = function(comp, meta) { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; },
+        peg$c43 = /^[a-zA-Z\/=_,0-9]/,
+        peg$c44 = { type: "class", value: "[a-zA-Z/=_,0-9]", description: "[a-zA-Z/=_,0-9]" },
+        peg$c45 = function(meta) {return meta},
+        peg$c46 = "[",
+        peg$c47 = { type: "literal", value: "[", description: "\"[\"" },
+        peg$c48 = /^[0-9]/,
+        peg$c49 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c50 = "]",
+        peg$c51 = { type: "literal", value: "]", description: "\"]\"" },
+        peg$c52 = function(portindex) {return parseInt(portindex.join(''))},
+        peg$c53 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }},
+        peg$c54 = /^[a-zA-Z.0-9_]/,
+        peg$c55 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
+        peg$c56 = function(portname) {return makeName(portname)},
+        peg$c57 = /^[^\n\r\u2028\u2029]/,
+        peg$c58 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
+        peg$c59 = /^[\\]/,
+        peg$c60 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
+        peg$c61 = /^[']/,
+        peg$c62 = { type: "class", value: "[']", description: "[']" },
+        peg$c63 = function() { return "'"; },
+        peg$c64 = /^[^']/,
+        peg$c65 = { type: "class", value: "[^']", description: "[^']" },
+        peg$c66 = " ",
+        peg$c67 = { type: "literal", value: " ", description: "\" \"" },
+        peg$c68 = function(value) { return value; },
+        peg$c69 = "{",
+        peg$c70 = { type: "literal", value: "{", description: "\"{\"" },
+        peg$c71 = "}",
+        peg$c72 = { type: "literal", value: "}", description: "\"}\"" },
+        peg$c73 = { type: "other", description: "whitespace" },
+        peg$c74 = /^[ \t\n\r]/,
+        peg$c75 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+        peg$c76 = "false",
+        peg$c77 = { type: "literal", value: "false", description: "\"false\"" },
+        peg$c78 = function() { return false; },
+        peg$c79 = "null",
+        peg$c80 = { type: "literal", value: "null", description: "\"null\"" },
+        peg$c81 = function() { return null;  },
+        peg$c82 = "true",
+        peg$c83 = { type: "literal", value: "true", description: "\"true\"" },
+        peg$c84 = function() { return true;  },
+        peg$c85 = function(head, m) { return m; },
+        peg$c86 = function(head, tail) {
                   var result = {}, i;
 
                   result[head.name] = head.value;
@@ -138,58 +133,58 @@ module.exports = (function() {
 
                   return result;
                 },
-        peg$c92 = function(members) { return members !== null ? members: {}; },
-        peg$c93 = function(name, value) {
+        peg$c87 = function(members) { return members !== null ? members: {}; },
+        peg$c88 = function(name, value) {
                 return { name: name, value: value };
               },
-        peg$c94 = function(head, v) { return v; },
-        peg$c95 = function(head, tail) { return [head].concat(tail); },
-        peg$c96 = function(values) { return values !== null ? values : []; },
-        peg$c97 = { type: "other", description: "number" },
-        peg$c98 = function() { return parseFloat(text()); },
-        peg$c99 = /^[1-9]/,
-        peg$c100 = { type: "class", value: "[1-9]", description: "[1-9]" },
-        peg$c101 = /^[eE]/,
-        peg$c102 = { type: "class", value: "[eE]", description: "[eE]" },
-        peg$c103 = "-",
-        peg$c104 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c105 = "+",
-        peg$c106 = { type: "literal", value: "+", description: "\"+\"" },
-        peg$c107 = "0",
-        peg$c108 = { type: "literal", value: "0", description: "\"0\"" },
-        peg$c109 = { type: "other", description: "string" },
-        peg$c110 = function(chars) { return chars.join(""); },
-        peg$c111 = "\"",
-        peg$c112 = { type: "literal", value: "\"", description: "\"\\\"\"" },
-        peg$c113 = "\\",
-        peg$c114 = { type: "literal", value: "\\", description: "\"\\\\\"" },
-        peg$c115 = "/",
-        peg$c116 = { type: "literal", value: "/", description: "\"/\"" },
-        peg$c117 = "b",
-        peg$c118 = { type: "literal", value: "b", description: "\"b\"" },
-        peg$c119 = function() { return "\b"; },
-        peg$c120 = "f",
-        peg$c121 = { type: "literal", value: "f", description: "\"f\"" },
-        peg$c122 = function() { return "\f"; },
-        peg$c123 = "n",
-        peg$c124 = { type: "literal", value: "n", description: "\"n\"" },
-        peg$c125 = function() { return "\n"; },
-        peg$c126 = "r",
-        peg$c127 = { type: "literal", value: "r", description: "\"r\"" },
-        peg$c128 = function() { return "\r"; },
-        peg$c129 = "t",
-        peg$c130 = { type: "literal", value: "t", description: "\"t\"" },
-        peg$c131 = function() { return "\t"; },
-        peg$c132 = "u",
-        peg$c133 = { type: "literal", value: "u", description: "\"u\"" },
-        peg$c134 = function(digits) {
+        peg$c89 = function(head, v) { return v; },
+        peg$c90 = function(head, tail) { return [head].concat(tail); },
+        peg$c91 = function(values) { return values !== null ? values : []; },
+        peg$c92 = { type: "other", description: "number" },
+        peg$c93 = function() { return parseFloat(text()); },
+        peg$c94 = /^[1-9]/,
+        peg$c95 = { type: "class", value: "[1-9]", description: "[1-9]" },
+        peg$c96 = /^[eE]/,
+        peg$c97 = { type: "class", value: "[eE]", description: "[eE]" },
+        peg$c98 = "-",
+        peg$c99 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c100 = "+",
+        peg$c101 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c102 = "0",
+        peg$c103 = { type: "literal", value: "0", description: "\"0\"" },
+        peg$c104 = { type: "other", description: "string" },
+        peg$c105 = function(chars) { return chars.join(""); },
+        peg$c106 = "\"",
+        peg$c107 = { type: "literal", value: "\"", description: "\"\\\"\"" },
+        peg$c108 = "\\",
+        peg$c109 = { type: "literal", value: "\\", description: "\"\\\\\"" },
+        peg$c110 = "/",
+        peg$c111 = { type: "literal", value: "/", description: "\"/\"" },
+        peg$c112 = "b",
+        peg$c113 = { type: "literal", value: "b", description: "\"b\"" },
+        peg$c114 = function() { return "\b"; },
+        peg$c115 = "f",
+        peg$c116 = { type: "literal", value: "f", description: "\"f\"" },
+        peg$c117 = function() { return "\f"; },
+        peg$c118 = "n",
+        peg$c119 = { type: "literal", value: "n", description: "\"n\"" },
+        peg$c120 = function() { return "\n"; },
+        peg$c121 = "r",
+        peg$c122 = { type: "literal", value: "r", description: "\"r\"" },
+        peg$c123 = function() { return "\r"; },
+        peg$c124 = "t",
+        peg$c125 = { type: "literal", value: "t", description: "\"t\"" },
+        peg$c126 = function() { return "\t"; },
+        peg$c127 = "u",
+        peg$c128 = { type: "literal", value: "u", description: "\"u\"" },
+        peg$c129 = function(digits) {
                     return String.fromCharCode(parseInt(digits, 16));
                   },
-        peg$c135 = function(sequence) { return sequence; },
-        peg$c136 = /^[^\0-\x1F"\\]/,
-        peg$c137 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
-        peg$c138 = /^[0-9a-f]/i,
-        peg$c139 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
+        peg$c130 = function(sequence) { return sequence; },
+        peg$c131 = /^[^\0-\x1F"\\]/,
+        peg$c132 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
+        peg$c133 = /^[0-9a-f]/i,
+        peg$c134 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -409,7 +404,7 @@ module.exports = (function() {
           if (peg$silentFails === 0) { peg$fail(peg$c2); }
         }
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsebasePort();
+          s3 = peg$parseportName();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
               s4 = peg$c3;
@@ -419,7 +414,7 @@ module.exports = (function() {
               if (peg$silentFails === 0) { peg$fail(peg$c4); }
             }
             if (s4 !== peg$FAILED) {
-              s5 = peg$parsebasePort();
+              s5 = peg$parseportName();
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
@@ -481,7 +476,7 @@ module.exports = (function() {
                 if (peg$silentFails === 0) { peg$fail(peg$c9); }
               }
               if (s4 !== peg$FAILED) {
-                s5 = peg$parsebasePort();
+                s5 = peg$parseportName();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 58) {
                     s6 = peg$c3;
@@ -491,7 +486,7 @@ module.exports = (function() {
                     if (peg$silentFails === 0) { peg$fail(peg$c4); }
                   }
                   if (s6 !== peg$FAILED) {
-                    s7 = peg$parsebasePort();
+                    s7 = peg$parseportName();
                     if (s7 !== peg$FAILED) {
                       s8 = peg$parse_();
                       if (s8 !== peg$FAILED) {
@@ -561,7 +556,7 @@ module.exports = (function() {
                   if (peg$silentFails === 0) { peg$fail(peg$c9); }
                 }
                 if (s4 !== peg$FAILED) {
-                  s5 = peg$parsebasePort();
+                  s5 = peg$parseportName();
                   if (s5 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 58) {
                       s6 = peg$c3;
@@ -571,7 +566,7 @@ module.exports = (function() {
                       if (peg$silentFails === 0) { peg$fail(peg$c4); }
                     }
                     if (s6 !== peg$FAILED) {
-                      s7 = peg$parsebasePort();
+                      s7 = peg$parseportName();
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse_();
                         if (s8 !== peg$FAILED) {
@@ -913,114 +908,6 @@ module.exports = (function() {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parseportWithIndex();
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse_();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parsenode();
-            if (s3 !== peg$FAILED) {
-              s4 = peg$parse_();
-              if (s4 !== peg$FAILED) {
-                s5 = peg$parseport();
-                if (s5 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c25(s1, s3, s5);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          s1 = peg$parseport();
-          if (s1 !== peg$FAILED) {
-            s2 = peg$parse_();
-            if (s2 !== peg$FAILED) {
-              s3 = peg$parsenode();
-              if (s3 !== peg$FAILED) {
-                s4 = peg$parse_();
-                if (s4 !== peg$FAILED) {
-                  s5 = peg$parseportWithIndex();
-                  if (s5 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c26(s1, s3, s5);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parseportWithIndex();
-            if (s1 !== peg$FAILED) {
-              s2 = peg$parse_();
-              if (s2 !== peg$FAILED) {
-                s3 = peg$parsenode();
-                if (s3 !== peg$FAILED) {
-                  s4 = peg$parse_();
-                  if (s4 !== peg$FAILED) {
-                    s5 = peg$parseportWithIndex();
-                    if (s5 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c27(s1, s3, s5);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          }
-        }
-      }
 
       return s0;
     }
@@ -1036,7 +923,7 @@ module.exports = (function() {
           s3 = peg$parseport();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c28(s1, s3);
+            s1 = peg$c25(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1050,30 +937,6 @@ module.exports = (function() {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parsenode();
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse_();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parseportWithIndex();
-            if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c29(s1, s3);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      }
 
       return s0;
     }
@@ -1083,11 +946,11 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c30;
+        s1 = peg$c26;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c31); }
+        if (peg$silentFails === 0) { peg$fail(peg$c27); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -1098,15 +961,15 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c30;
+            s3 = peg$c26;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c31); }
+            if (peg$silentFails === 0) { peg$fail(peg$c27); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c32(s2);
+            s1 = peg$c28(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1125,7 +988,7 @@ module.exports = (function() {
         s1 = peg$parseJSON_text();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c33(s1);
+          s1 = peg$c29(s1);
         }
         s0 = s1;
       }
@@ -1144,7 +1007,7 @@ module.exports = (function() {
           s3 = peg$parsenode();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c34(s1, s3);
+            s1 = peg$c30(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1158,30 +1021,6 @@ module.exports = (function() {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parseportWithIndex();
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse_();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parsenode();
-            if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c35(s1, s3);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      }
 
       return s0;
     }
@@ -1191,30 +1030,30 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (peg$c36.test(input.charAt(peg$currPos))) {
+      if (peg$c31.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+        if (peg$silentFails === 0) { peg$fail(peg$c32); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c38.test(input.charAt(peg$currPos))) {
+        if (peg$c33.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c39); }
+          if (peg$silentFails === 0) { peg$fail(peg$c34); }
         }
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          if (peg$c38.test(input.charAt(peg$currPos))) {
+          if (peg$c33.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c39); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -1235,7 +1074,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c40(s1, s2);
+          s1 = peg$c35(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1254,29 +1093,29 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c41;
+        s1 = peg$c36;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c42); }
+        if (peg$silentFails === 0) { peg$fail(peg$c37); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c43.test(input.charAt(peg$currPos))) {
+        if (peg$c38.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c39); }
         }
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c43.test(input.charAt(peg$currPos))) {
+          if (peg$c38.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c39); }
           }
         }
         if (s2 === peg$FAILED) {
@@ -1289,15 +1128,15 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s4 = peg$c45;
+              s4 = peg$c40;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c46); }
+              if (peg$silentFails === 0) { peg$fail(peg$c41); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c47(s2, s3);
+              s1 = peg$c42(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1332,6 +1171,56 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
+        if (peg$c43.test(input.charAt(peg$currPos))) {
+          s3 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            if (peg$c43.test(input.charAt(peg$currPos))) {
+              s3 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            }
+          }
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c45(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parseportIndex() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 91) {
+        s1 = peg$c46;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = [];
         if (peg$c48.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
@@ -1354,102 +1243,17 @@ module.exports = (function() {
           s2 = peg$FAILED;
         }
         if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c50(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      return s0;
-    }
-
-    function peg$parseport() {
-      var s0, s1, s2;
-
-      s0 = peg$currPos;
-      s1 = peg$parsebasePort();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c51(s1);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      return s0;
-    }
-
-    function peg$parseportWithIndex() {
-      var s0, s1, s2, s3, s4, s5;
-
-      s0 = peg$currPos;
-      s1 = peg$parsebasePort();
-      if (s1 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c52;
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = [];
-          if (peg$c54.test(input.charAt(peg$currPos))) {
-            s4 = input.charAt(peg$currPos);
+          if (input.charCodeAt(peg$currPos) === 93) {
+            s3 = peg$c50;
             peg$currPos++;
           } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
-          }
-          if (s4 !== peg$FAILED) {
-            while (s4 !== peg$FAILED) {
-              s3.push(s4);
-              if (peg$c54.test(input.charAt(peg$currPos))) {
-                s4 = input.charAt(peg$currPos);
-                peg$currPos++;
-              } else {
-                s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c55); }
-              }
-            }
-          } else {
             s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c51); }
           }
           if (s3 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c56;
-              peg$currPos++;
-            } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c57); }
-            }
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parse__();
-              if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c58(s1, s3);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
+            peg$savedPos = s0;
+            s1 = peg$c52(s2);
+            s0 = s1;
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1466,35 +1270,67 @@ module.exports = (function() {
       return s0;
     }
 
-    function peg$parsebasePort() {
+    function peg$parseport() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      s1 = peg$parseportName();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseportIndex();
+        if (s2 === peg$FAILED) {
+          s2 = null;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse__();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c53(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parseportName() {
       var s0, s1, s2, s3, s4;
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (peg$c36.test(input.charAt(peg$currPos))) {
+      if (peg$c31.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+        if (peg$silentFails === 0) { peg$fail(peg$c32); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c59.test(input.charAt(peg$currPos))) {
+        if (peg$c54.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c60); }
+          if (peg$silentFails === 0) { peg$fail(peg$c55); }
         }
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          if (peg$c59.test(input.charAt(peg$currPos))) {
+          if (peg$c54.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c60); }
+            if (peg$silentFails === 0) { peg$fail(peg$c55); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -1510,7 +1346,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c61(s1);
+        s1 = peg$c56(s1);
       }
       s0 = s1;
 
@@ -1520,12 +1356,12 @@ module.exports = (function() {
     function peg$parseanychar() {
       var s0;
 
-      if (peg$c62.test(input.charAt(peg$currPos))) {
+      if (peg$c57.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c63); }
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
       }
 
       return s0;
@@ -1535,24 +1371,24 @@ module.exports = (function() {
       var s0, s1, s2;
 
       s0 = peg$currPos;
-      if (peg$c64.test(input.charAt(peg$currPos))) {
+      if (peg$c59.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c65); }
+        if (peg$silentFails === 0) { peg$fail(peg$c60); }
       }
       if (s1 !== peg$FAILED) {
-        if (peg$c66.test(input.charAt(peg$currPos))) {
+        if (peg$c61.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c67); }
+          if (peg$silentFails === 0) { peg$fail(peg$c62); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c68();
+          s1 = peg$c63();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1563,12 +1399,12 @@ module.exports = (function() {
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
-        if (peg$c69.test(input.charAt(peg$currPos))) {
+        if (peg$c64.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
       }
 
@@ -1580,20 +1416,20 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c71;
+        s1 = peg$c66;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c72); }
+        if (peg$silentFails === 0) { peg$fail(peg$c67); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
         if (input.charCodeAt(peg$currPos) === 32) {
-          s1 = peg$c71;
+          s1 = peg$c66;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c72); }
+          if (peg$silentFails === 0) { peg$fail(peg$c67); }
         }
       }
       if (s0 === peg$FAILED) {
@@ -1608,21 +1444,21 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c71;
+        s1 = peg$c66;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c72); }
+        if (peg$silentFails === 0) { peg$fail(peg$c67); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
           if (input.charCodeAt(peg$currPos) === 32) {
-            s1 = peg$c71;
+            s1 = peg$c66;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c72); }
+            if (peg$silentFails === 0) { peg$fail(peg$c67); }
           }
         }
       } else {
@@ -1643,7 +1479,7 @@ module.exports = (function() {
           s3 = peg$parsews();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c73(s2);
+            s1 = peg$c68(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1668,11 +1504,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c52;
+          s2 = peg$c46;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1702,11 +1538,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c74;
+          s2 = peg$c69;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c75); }
+          if (peg$silentFails === 0) { peg$fail(peg$c70); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1736,11 +1572,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s2 = peg$c56;
+          s2 = peg$c50;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c57); }
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1770,11 +1606,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 125) {
-          s2 = peg$c76;
+          s2 = peg$c71;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c77); }
+          if (peg$silentFails === 0) { peg$fail(peg$c72); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1870,27 +1706,27 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c79.test(input.charAt(peg$currPos))) {
+      if (peg$c74.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+        if (peg$silentFails === 0) { peg$fail(peg$c75); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c79.test(input.charAt(peg$currPos))) {
+        if (peg$c74.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c75); }
         }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
 
       return s0;
@@ -1926,16 +1762,16 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c81) {
-        s1 = peg$c81;
+      if (input.substr(peg$currPos, 5) === peg$c76) {
+        s1 = peg$c76;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c83();
+        s1 = peg$c78();
       }
       s0 = s1;
 
@@ -1946,16 +1782,16 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c84) {
-        s1 = peg$c84;
+      if (input.substr(peg$currPos, 4) === peg$c79) {
+        s1 = peg$c79;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c86();
+        s1 = peg$c81();
       }
       s0 = s1;
 
@@ -1966,16 +1802,16 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c87) {
-        s1 = peg$c87;
+      if (input.substr(peg$currPos, 4) === peg$c82) {
+        s1 = peg$c82;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c88); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c89();
+        s1 = peg$c84();
       }
       s0 = s1;
 
@@ -1998,7 +1834,7 @@ module.exports = (function() {
             s7 = peg$parsemember();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s5;
-              s6 = peg$c90(s3, s7);
+              s6 = peg$c85(s3, s7);
               s5 = s6;
             } else {
               peg$currPos = s5;
@@ -2016,7 +1852,7 @@ module.exports = (function() {
               s7 = peg$parsemember();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c90(s3, s7);
+                s6 = peg$c85(s3, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -2029,7 +1865,7 @@ module.exports = (function() {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c91(s3, s4);
+            s3 = peg$c86(s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2046,7 +1882,7 @@ module.exports = (function() {
           s3 = peg$parseend_object();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c92(s2);
+            s1 = peg$c87(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2075,7 +1911,7 @@ module.exports = (function() {
           s3 = peg$parsevalue();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c93(s1, s3);
+            s1 = peg$c88(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2109,7 +1945,7 @@ module.exports = (function() {
             s7 = peg$parsevalue();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s5;
-              s6 = peg$c94(s3, s7);
+              s6 = peg$c89(s3, s7);
               s5 = s6;
             } else {
               peg$currPos = s5;
@@ -2127,7 +1963,7 @@ module.exports = (function() {
               s7 = peg$parsevalue();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c94(s3, s7);
+                s6 = peg$c89(s3, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -2140,7 +1976,7 @@ module.exports = (function() {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c95(s3, s4);
+            s3 = peg$c90(s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2157,7 +1993,7 @@ module.exports = (function() {
           s3 = peg$parseend_array();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c96(s2);
+            s1 = peg$c91(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2198,7 +2034,7 @@ module.exports = (function() {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c98();
+              s1 = peg$c93();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2219,7 +2055,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c92); }
       }
 
       return s0;
@@ -2242,12 +2078,12 @@ module.exports = (function() {
     function peg$parsedigit1_9() {
       var s0;
 
-      if (peg$c99.test(input.charAt(peg$currPos))) {
+      if (peg$c94.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+        if (peg$silentFails === 0) { peg$fail(peg$c95); }
       }
 
       return s0;
@@ -2256,12 +2092,12 @@ module.exports = (function() {
     function peg$parsee() {
       var s0;
 
-      if (peg$c101.test(input.charAt(peg$currPos))) {
+      if (peg$c96.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
       }
 
       return s0;
@@ -2375,11 +2211,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c103;
+        s0 = peg$c98;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c104); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
 
       return s0;
@@ -2389,11 +2225,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 43) {
-        s0 = peg$c105;
+        s0 = peg$c100;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c106); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
 
       return s0;
@@ -2403,11 +2239,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 48) {
-        s0 = peg$c107;
+        s0 = peg$c102;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c108); }
+        if (peg$silentFails === 0) { peg$fail(peg$c103); }
       }
 
       return s0;
@@ -2430,7 +2266,7 @@ module.exports = (function() {
           s3 = peg$parsequotation_mark();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c110(s2);
+            s1 = peg$c105(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2447,7 +2283,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c109); }
+        if (peg$silentFails === 0) { peg$fail(peg$c104); }
       }
 
       return s0;
@@ -2462,106 +2298,106 @@ module.exports = (function() {
         s1 = peg$parseescape();
         if (s1 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 34) {
-            s2 = peg$c111;
+            s2 = peg$c106;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c112); }
+            if (peg$silentFails === 0) { peg$fail(peg$c107); }
           }
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 92) {
-              s2 = peg$c113;
+              s2 = peg$c108;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c114); }
+              if (peg$silentFails === 0) { peg$fail(peg$c109); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 47) {
-                s2 = peg$c115;
+                s2 = peg$c110;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c116); }
+                if (peg$silentFails === 0) { peg$fail(peg$c111); }
               }
               if (s2 === peg$FAILED) {
                 s2 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 98) {
-                  s3 = peg$c117;
+                  s3 = peg$c112;
                   peg$currPos++;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c118); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c113); }
                 }
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s2;
-                  s3 = peg$c119();
+                  s3 = peg$c114();
                 }
                 s2 = s3;
                 if (s2 === peg$FAILED) {
                   s2 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 102) {
-                    s3 = peg$c120;
+                    s3 = peg$c115;
                     peg$currPos++;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c116); }
                   }
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s2;
-                    s3 = peg$c122();
+                    s3 = peg$c117();
                   }
                   s2 = s3;
                   if (s2 === peg$FAILED) {
                     s2 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 110) {
-                      s3 = peg$c123;
+                      s3 = peg$c118;
                       peg$currPos++;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c124); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c119); }
                     }
                     if (s3 !== peg$FAILED) {
                       peg$savedPos = s2;
-                      s3 = peg$c125();
+                      s3 = peg$c120();
                     }
                     s2 = s3;
                     if (s2 === peg$FAILED) {
                       s2 = peg$currPos;
                       if (input.charCodeAt(peg$currPos) === 114) {
-                        s3 = peg$c126;
+                        s3 = peg$c121;
                         peg$currPos++;
                       } else {
                         s3 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c127); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c122); }
                       }
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s2;
-                        s3 = peg$c128();
+                        s3 = peg$c123();
                       }
                       s2 = s3;
                       if (s2 === peg$FAILED) {
                         s2 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 116) {
-                          s3 = peg$c129;
+                          s3 = peg$c124;
                           peg$currPos++;
                         } else {
                           s3 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c130); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c125); }
                         }
                         if (s3 !== peg$FAILED) {
                           peg$savedPos = s2;
-                          s3 = peg$c131();
+                          s3 = peg$c126();
                         }
                         s2 = s3;
                         if (s2 === peg$FAILED) {
                           s2 = peg$currPos;
                           if (input.charCodeAt(peg$currPos) === 117) {
-                            s3 = peg$c132;
+                            s3 = peg$c127;
                             peg$currPos++;
                           } else {
                             s3 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c128); }
                           }
                           if (s3 !== peg$FAILED) {
                             s4 = peg$currPos;
@@ -2599,7 +2435,7 @@ module.exports = (function() {
                             }
                             if (s4 !== peg$FAILED) {
                               peg$savedPos = s2;
-                              s3 = peg$c134(s4);
+                              s3 = peg$c129(s4);
                               s2 = s3;
                             } else {
                               peg$currPos = s2;
@@ -2619,7 +2455,7 @@ module.exports = (function() {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c135(s2);
+            s1 = peg$c130(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2638,11 +2474,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 92) {
-        s0 = peg$c113;
+        s0 = peg$c108;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
 
       return s0;
@@ -2652,11 +2488,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c111;
+        s0 = peg$c106;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c112); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
 
       return s0;
@@ -2665,12 +2501,12 @@ module.exports = (function() {
     function peg$parseunescaped() {
       var s0;
 
-      if (peg$c136.test(input.charAt(peg$currPos))) {
+      if (peg$c131.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c137); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
 
       return s0;
@@ -2679,12 +2515,12 @@ module.exports = (function() {
     function peg$parseDIGIT() {
       var s0;
 
-      if (peg$c54.test(input.charAt(peg$currPos))) {
+      if (peg$c48.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c49); }
       }
 
       return s0;
@@ -2693,19 +2529,19 @@ module.exports = (function() {
     function peg$parseHEXDIG() {
       var s0;
 
-      if (peg$c138.test(input.charAt(peg$currPos))) {
+      if (peg$c133.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c139); }
+        if (peg$silentFails === 0) { peg$fail(peg$c134); }
       }
 
       return s0;
     }
 
 
-      var parser, edges, nodes; 
+      var parser, edges, nodes;
 
       parser = this;
       delete parser.exports;
@@ -2739,7 +2575,7 @@ module.exports = (function() {
           }
           nodes[nodeName].metadata=metadata;
         }
-       
+
       }
 
       parser.getResult = function () {
@@ -2765,7 +2601,7 @@ module.exports = (function() {
         }
         result.caseSensitive = options.caseSensitive;
         return result;
-      }  
+      }
 
       var flatten = function (array, isShallow) {
         var index = -1,
@@ -2784,7 +2620,7 @@ module.exports = (function() {
         }
         return result;
       }
-      
+
       parser.registerExports = function (priv, pub) {
         if (!parser.exports) {
           parser.exports = [];
@@ -2827,15 +2663,15 @@ module.exports = (function() {
         edges.forEach(function (o, i) {
           parser.edges.push(o);
         });
-      }  
+      }
 
-      parser.processEdges = function () {   
+      parser.processEdges = function () {
         var flats, grouped;
         flats = flatten(parser.edges);
         grouped = [];
         var current = {};
         flats.forEach(function (o, i) {
-          if (i % 2 !== 0) { 
+          if (i % 2 !== 0) {
             var pair = grouped[grouped.length - 1];
             pair.tgt = o.tgt;
             return;
@@ -2847,6 +2683,14 @@ module.exports = (function() {
 
       function makeName(s) {
         return s[0] + s[1].join("");
+      }
+
+      function makePort(process, port, index) {
+        var p = { process: process, port: port };
+        if (index != null) {
+            p.index = index;
+        }
+        return p;
       }
 
 

--- a/lib/fbp.js
+++ b/lib/fbp.js
@@ -60,13 +60,13 @@ module.exports = (function() {
         peg$c21 = "->",
         peg$c22 = { type: "literal", value: "->", description: "\"->\"" },
         peg$c23 = function(x, y) { return [x,y]; },
-        peg$c24 = function(x, proc, y) { return [{"tgt":makePort(proc, x.port, x.index)},{"src":makePort(proc, y.port, y.index)}]; },
-        peg$c25 = function(proc, port) { return {"src":makePort(proc, port.port, port.index)} },
+        peg$c24 = function(x, proc, y) { return [{"tgt":makeInPort(proc, x)},{"src":makeOutPort(proc, y)}]; },
+        peg$c25 = function(proc, port) { return {"src":makeOutPort(proc, port)} },
         peg$c26 = "'",
         peg$c27 = { type: "literal", value: "'", description: "\"'\"" },
         peg$c28 = function(iip) { return {"data":iip.join("")} },
         peg$c29 = function(iip) { return {"data":iip} },
-        peg$c30 = function(port, proc) { return {"tgt":makePort(proc, port.port, port.index)} },
+        peg$c30 = function(port, proc) { return {"tgt":makeInPort(proc, port)} },
         peg$c31 = function(name) { return name},
         peg$c32 = /^[a-zA-Z_]/,
         peg$c33 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
@@ -2757,12 +2757,19 @@ module.exports = (function() {
         return s[0] + s[1].join("");
       }
 
-      function makePort(process, port, index) {
-        var p = { process: process, port: port };
-        if (index != null) {
-            p.index = index;
+      function makePort(process, port, defaultPort) {
+        var p = { process: process, port: port ? port.port : defaultPort };
+        if (port && port.index != null) {
+            p.index = port.index;
         }
         return p;
+    }
+
+      function makeInPort(process, port) {
+          return makePort(process, port, "IN");
+      }
+      function makeOutPort(process, port) {
+          return makePort(process, port, "OUT");
       }
 
 

--- a/lib/fbp.js
+++ b/lib/fbp.js
@@ -67,62 +67,65 @@ module.exports = (function() {
         peg$c28 = function(iip) { return {"data":iip.join("")} },
         peg$c29 = function(iip) { return {"data":iip} },
         peg$c30 = function(port, proc) { return {"tgt":makePort(proc, port.port, port.index)} },
-        peg$c31 = /^[a-zA-Z_]/,
-        peg$c32 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
-        peg$c33 = /^[a-zA-Z0-9_\-]/,
-        peg$c34 = { type: "class", value: "[a-zA-Z0-9_\\-]", description: "[a-zA-Z0-9_\\-]" },
-        peg$c35 = function(node, comp) { if(comp){parser.addNode(makeName(node),comp);}; return makeName(node)},
-        peg$c36 = "(",
-        peg$c37 = { type: "literal", value: "(", description: "\"(\"" },
-        peg$c38 = /^[a-zA-Z\/\-0-9_]/,
-        peg$c39 = { type: "class", value: "[a-zA-Z/\\-0-9_]", description: "[a-zA-Z/\\-0-9_]" },
-        peg$c40 = ")",
-        peg$c41 = { type: "literal", value: ")", description: "\")\"" },
-        peg$c42 = function(comp, meta) { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; },
-        peg$c43 = /^[a-zA-Z\/=_,0-9]/,
-        peg$c44 = { type: "class", value: "[a-zA-Z/=_,0-9]", description: "[a-zA-Z/=_,0-9]" },
-        peg$c45 = function(meta) {return meta},
-        peg$c46 = "[",
-        peg$c47 = { type: "literal", value: "[", description: "\"[\"" },
-        peg$c48 = /^[0-9]/,
-        peg$c49 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c50 = "]",
-        peg$c51 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c52 = function(portindex) {return parseInt(portindex.join(''))},
-        peg$c53 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }},
-        peg$c54 = /^[a-zA-Z.0-9_]/,
-        peg$c55 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
-        peg$c56 = function(portname) {return makeName(portname)},
-        peg$c57 = /^[^\n\r\u2028\u2029]/,
-        peg$c58 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
-        peg$c59 = /^[\\]/,
-        peg$c60 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
-        peg$c61 = /^[']/,
-        peg$c62 = { type: "class", value: "[']", description: "[']" },
-        peg$c63 = function() { return "'"; },
-        peg$c64 = /^[^']/,
-        peg$c65 = { type: "class", value: "[^']", description: "[^']" },
-        peg$c66 = " ",
-        peg$c67 = { type: "literal", value: " ", description: "\" \"" },
-        peg$c68 = function(value) { return value; },
-        peg$c69 = "{",
-        peg$c70 = { type: "literal", value: "{", description: "\"{\"" },
-        peg$c71 = "}",
-        peg$c72 = { type: "literal", value: "}", description: "\"}\"" },
-        peg$c73 = { type: "other", description: "whitespace" },
-        peg$c74 = /^[ \t\n\r]/,
-        peg$c75 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
-        peg$c76 = "false",
-        peg$c77 = { type: "literal", value: "false", description: "\"false\"" },
-        peg$c78 = function() { return false; },
-        peg$c79 = "null",
-        peg$c80 = { type: "literal", value: "null", description: "\"null\"" },
-        peg$c81 = function() { return null;  },
-        peg$c82 = "true",
-        peg$c83 = { type: "literal", value: "true", description: "\"true\"" },
-        peg$c84 = function() { return true;  },
-        peg$c85 = function(head, m) { return m; },
-        peg$c86 = function(head, tail) {
+        peg$c31 = function(name) { return name},
+        peg$c32 = /^[a-zA-Z_]/,
+        peg$c33 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
+        peg$c34 = /^[a-zA-Z0-9_\-]/,
+        peg$c35 = { type: "class", value: "[a-zA-Z0-9_\\-]", description: "[a-zA-Z0-9_\\-]" },
+        peg$c36 = function(name) { return makeName(name)},
+        peg$c37 = function(name, comp) { parser.addNode(name,comp); return name},
+        peg$c38 = function(comp) { return parser.addAnonymousNode(comp, location().start.offset) },
+        peg$c39 = "(",
+        peg$c40 = { type: "literal", value: "(", description: "\"(\"" },
+        peg$c41 = /^[a-zA-Z\/\-0-9_]/,
+        peg$c42 = { type: "class", value: "[a-zA-Z/\\-0-9_]", description: "[a-zA-Z/\\-0-9_]" },
+        peg$c43 = ")",
+        peg$c44 = { type: "literal", value: ")", description: "\")\"" },
+        peg$c45 = function(comp, meta) { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; },
+        peg$c46 = /^[a-zA-Z\/=_,0-9]/,
+        peg$c47 = { type: "class", value: "[a-zA-Z/=_,0-9]", description: "[a-zA-Z/=_,0-9]" },
+        peg$c48 = function(meta) {return meta},
+        peg$c49 = "[",
+        peg$c50 = { type: "literal", value: "[", description: "\"[\"" },
+        peg$c51 = /^[0-9]/,
+        peg$c52 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c53 = "]",
+        peg$c54 = { type: "literal", value: "]", description: "\"]\"" },
+        peg$c55 = function(portindex) {return parseInt(portindex.join(''))},
+        peg$c56 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }},
+        peg$c57 = /^[a-zA-Z.0-9_]/,
+        peg$c58 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
+        peg$c59 = function(portname) {return makeName(portname)},
+        peg$c60 = /^[^\n\r\u2028\u2029]/,
+        peg$c61 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
+        peg$c62 = /^[\\]/,
+        peg$c63 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
+        peg$c64 = /^[']/,
+        peg$c65 = { type: "class", value: "[']", description: "[']" },
+        peg$c66 = function() { return "'"; },
+        peg$c67 = /^[^']/,
+        peg$c68 = { type: "class", value: "[^']", description: "[^']" },
+        peg$c69 = " ",
+        peg$c70 = { type: "literal", value: " ", description: "\" \"" },
+        peg$c71 = function(value) { return value; },
+        peg$c72 = "{",
+        peg$c73 = { type: "literal", value: "{", description: "\"{\"" },
+        peg$c74 = "}",
+        peg$c75 = { type: "literal", value: "}", description: "\"}\"" },
+        peg$c76 = { type: "other", description: "whitespace" },
+        peg$c77 = /^[ \t\n\r]/,
+        peg$c78 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+        peg$c79 = "false",
+        peg$c80 = { type: "literal", value: "false", description: "\"false\"" },
+        peg$c81 = function() { return false; },
+        peg$c82 = "null",
+        peg$c83 = { type: "literal", value: "null", description: "\"null\"" },
+        peg$c84 = function() { return null;  },
+        peg$c85 = "true",
+        peg$c86 = { type: "literal", value: "true", description: "\"true\"" },
+        peg$c87 = function() { return true;  },
+        peg$c88 = function(head, m) { return m; },
+        peg$c89 = function(head, tail) {
                   var result = {}, i;
 
                   result[head.name] = head.value;
@@ -133,58 +136,58 @@ module.exports = (function() {
 
                   return result;
                 },
-        peg$c87 = function(members) { return members !== null ? members: {}; },
-        peg$c88 = function(name, value) {
+        peg$c90 = function(members) { return members !== null ? members: {}; },
+        peg$c91 = function(name, value) {
                 return { name: name, value: value };
               },
-        peg$c89 = function(head, v) { return v; },
-        peg$c90 = function(head, tail) { return [head].concat(tail); },
-        peg$c91 = function(values) { return values !== null ? values : []; },
-        peg$c92 = { type: "other", description: "number" },
-        peg$c93 = function() { return parseFloat(text()); },
-        peg$c94 = /^[1-9]/,
-        peg$c95 = { type: "class", value: "[1-9]", description: "[1-9]" },
-        peg$c96 = /^[eE]/,
-        peg$c97 = { type: "class", value: "[eE]", description: "[eE]" },
-        peg$c98 = "-",
-        peg$c99 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c100 = "+",
-        peg$c101 = { type: "literal", value: "+", description: "\"+\"" },
-        peg$c102 = "0",
-        peg$c103 = { type: "literal", value: "0", description: "\"0\"" },
-        peg$c104 = { type: "other", description: "string" },
-        peg$c105 = function(chars) { return chars.join(""); },
-        peg$c106 = "\"",
-        peg$c107 = { type: "literal", value: "\"", description: "\"\\\"\"" },
-        peg$c108 = "\\",
-        peg$c109 = { type: "literal", value: "\\", description: "\"\\\\\"" },
-        peg$c110 = "/",
-        peg$c111 = { type: "literal", value: "/", description: "\"/\"" },
-        peg$c112 = "b",
-        peg$c113 = { type: "literal", value: "b", description: "\"b\"" },
-        peg$c114 = function() { return "\b"; },
-        peg$c115 = "f",
-        peg$c116 = { type: "literal", value: "f", description: "\"f\"" },
-        peg$c117 = function() { return "\f"; },
-        peg$c118 = "n",
-        peg$c119 = { type: "literal", value: "n", description: "\"n\"" },
-        peg$c120 = function() { return "\n"; },
-        peg$c121 = "r",
-        peg$c122 = { type: "literal", value: "r", description: "\"r\"" },
-        peg$c123 = function() { return "\r"; },
-        peg$c124 = "t",
-        peg$c125 = { type: "literal", value: "t", description: "\"t\"" },
-        peg$c126 = function() { return "\t"; },
-        peg$c127 = "u",
-        peg$c128 = { type: "literal", value: "u", description: "\"u\"" },
-        peg$c129 = function(digits) {
+        peg$c92 = function(head, v) { return v; },
+        peg$c93 = function(head, tail) { return [head].concat(tail); },
+        peg$c94 = function(values) { return values !== null ? values : []; },
+        peg$c95 = { type: "other", description: "number" },
+        peg$c96 = function() { return parseFloat(text()); },
+        peg$c97 = /^[1-9]/,
+        peg$c98 = { type: "class", value: "[1-9]", description: "[1-9]" },
+        peg$c99 = /^[eE]/,
+        peg$c100 = { type: "class", value: "[eE]", description: "[eE]" },
+        peg$c101 = "-",
+        peg$c102 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c103 = "+",
+        peg$c104 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c105 = "0",
+        peg$c106 = { type: "literal", value: "0", description: "\"0\"" },
+        peg$c107 = { type: "other", description: "string" },
+        peg$c108 = function(chars) { return chars.join(""); },
+        peg$c109 = "\"",
+        peg$c110 = { type: "literal", value: "\"", description: "\"\\\"\"" },
+        peg$c111 = "\\",
+        peg$c112 = { type: "literal", value: "\\", description: "\"\\\\\"" },
+        peg$c113 = "/",
+        peg$c114 = { type: "literal", value: "/", description: "\"/\"" },
+        peg$c115 = "b",
+        peg$c116 = { type: "literal", value: "b", description: "\"b\"" },
+        peg$c117 = function() { return "\b"; },
+        peg$c118 = "f",
+        peg$c119 = { type: "literal", value: "f", description: "\"f\"" },
+        peg$c120 = function() { return "\f"; },
+        peg$c121 = "n",
+        peg$c122 = { type: "literal", value: "n", description: "\"n\"" },
+        peg$c123 = function() { return "\n"; },
+        peg$c124 = "r",
+        peg$c125 = { type: "literal", value: "r", description: "\"r\"" },
+        peg$c126 = function() { return "\r"; },
+        peg$c127 = "t",
+        peg$c128 = { type: "literal", value: "t", description: "\"t\"" },
+        peg$c129 = function() { return "\t"; },
+        peg$c130 = "u",
+        peg$c131 = { type: "literal", value: "u", description: "\"u\"" },
+        peg$c132 = function(digits) {
                     return String.fromCharCode(parseInt(digits, 16));
                   },
-        peg$c130 = function(sequence) { return sequence; },
-        peg$c131 = /^[^\0-\x1F"\\]/,
-        peg$c132 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
-        peg$c133 = /^[0-9a-f]/i,
-        peg$c134 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
+        peg$c133 = function(sequence) { return sequence; },
+        peg$c134 = /^[^\0-\x1F"\\]/,
+        peg$c135 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
+        peg$c136 = /^[0-9a-f]/i,
+        peg$c137 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -1026,34 +1029,66 @@ module.exports = (function() {
     }
 
     function peg$parsenode() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      s1 = peg$parsenodeNameAndComponent();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c31(s1);
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsenodeName();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c31(s1);
+        }
+        s0 = s1;
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsenodeComponent();
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c31(s1);
+          }
+          s0 = s1;
+        }
+      }
+
+      return s0;
+    }
+
+    function peg$parsenodeName() {
       var s0, s1, s2, s3, s4;
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (peg$c31.test(input.charAt(peg$currPos))) {
+      if (peg$c32.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c32); }
+        if (peg$silentFails === 0) { peg$fail(peg$c33); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c33.test(input.charAt(peg$currPos))) {
+        if (peg$c34.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c34); }
+          if (peg$silentFails === 0) { peg$fail(peg$c35); }
         }
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          if (peg$c33.test(input.charAt(peg$currPos))) {
+          if (peg$c34.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c34); }
+            if (peg$silentFails === 0) { peg$fail(peg$c35); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -1068,13 +1103,24 @@ module.exports = (function() {
         s1 = peg$FAILED;
       }
       if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c36(s1);
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parsenodeNameAndComponent() {
+      var s0, s1, s2;
+
+      s0 = peg$currPos;
+      s1 = peg$parsenodeName();
+      if (s1 !== peg$FAILED) {
         s2 = peg$parsecomponent();
-        if (s2 === peg$FAILED) {
-          s2 = null;
-        }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c35(s1, s2);
+          s1 = peg$c37(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1088,34 +1134,48 @@ module.exports = (function() {
       return s0;
     }
 
+    function peg$parsenodeComponent() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      s1 = peg$parsecomponent();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c38(s1);
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
     function peg$parsecomponent() {
       var s0, s1, s2, s3, s4;
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c36;
+        s1 = peg$c39;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+        if (peg$silentFails === 0) { peg$fail(peg$c40); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c38.test(input.charAt(peg$currPos))) {
+        if (peg$c41.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c39); }
+          if (peg$silentFails === 0) { peg$fail(peg$c42); }
         }
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c38.test(input.charAt(peg$currPos))) {
+          if (peg$c41.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c39); }
+            if (peg$silentFails === 0) { peg$fail(peg$c42); }
           }
         }
         if (s2 === peg$FAILED) {
@@ -1128,15 +1188,15 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s4 = peg$c40;
+              s4 = peg$c43;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c41); }
+              if (peg$silentFails === 0) { peg$fail(peg$c44); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c42(s2, s3);
+              s1 = peg$c45(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1171,22 +1231,22 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c43.test(input.charAt(peg$currPos))) {
+        if (peg$c46.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c43.test(input.charAt(peg$currPos))) {
+            if (peg$c46.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+              if (peg$silentFails === 0) { peg$fail(peg$c47); }
             }
           }
         } else {
@@ -1194,7 +1254,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c45(s2);
+          s1 = peg$c48(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1213,30 +1273,30 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c46;
+        s1 = peg$c49;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c47); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c48.test(input.charAt(peg$currPos))) {
+        if (peg$c51.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+          if (peg$silentFails === 0) { peg$fail(peg$c52); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c48.test(input.charAt(peg$currPos))) {
+            if (peg$c51.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c49); }
+              if (peg$silentFails === 0) { peg$fail(peg$c52); }
             }
           }
         } else {
@@ -1244,15 +1304,15 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 93) {
-            s3 = peg$c50;
+            s3 = peg$c53;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c51); }
+            if (peg$silentFails === 0) { peg$fail(peg$c54); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c52(s2);
+            s1 = peg$c55(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1284,7 +1344,7 @@ module.exports = (function() {
           s3 = peg$parse__();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c53(s1, s2);
+            s1 = peg$c56(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1307,30 +1367,30 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (peg$c31.test(input.charAt(peg$currPos))) {
+      if (peg$c32.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c32); }
+        if (peg$silentFails === 0) { peg$fail(peg$c33); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c54.test(input.charAt(peg$currPos))) {
+        if (peg$c57.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c58); }
         }
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          if (peg$c54.test(input.charAt(peg$currPos))) {
+          if (peg$c57.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c58); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -1346,7 +1406,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c56(s1);
+        s1 = peg$c59(s1);
       }
       s0 = s1;
 
@@ -1356,12 +1416,12 @@ module.exports = (function() {
     function peg$parseanychar() {
       var s0;
 
-      if (peg$c57.test(input.charAt(peg$currPos))) {
+      if (peg$c60.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c58); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
       }
 
       return s0;
@@ -1371,24 +1431,24 @@ module.exports = (function() {
       var s0, s1, s2;
 
       s0 = peg$currPos;
-      if (peg$c59.test(input.charAt(peg$currPos))) {
+      if (peg$c62.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c60); }
+        if (peg$silentFails === 0) { peg$fail(peg$c63); }
       }
       if (s1 !== peg$FAILED) {
-        if (peg$c61.test(input.charAt(peg$currPos))) {
+        if (peg$c64.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c62); }
+          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c63();
+          s1 = peg$c66();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1399,12 +1459,12 @@ module.exports = (function() {
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
-        if (peg$c64.test(input.charAt(peg$currPos))) {
+        if (peg$c67.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c68); }
         }
       }
 
@@ -1416,20 +1476,20 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c66;
+        s1 = peg$c69;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c67); }
+        if (peg$silentFails === 0) { peg$fail(peg$c70); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
         if (input.charCodeAt(peg$currPos) === 32) {
-          s1 = peg$c66;
+          s1 = peg$c69;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c67); }
+          if (peg$silentFails === 0) { peg$fail(peg$c70); }
         }
       }
       if (s0 === peg$FAILED) {
@@ -1444,21 +1504,21 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c66;
+        s1 = peg$c69;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c67); }
+        if (peg$silentFails === 0) { peg$fail(peg$c70); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
           if (input.charCodeAt(peg$currPos) === 32) {
-            s1 = peg$c66;
+            s1 = peg$c69;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c67); }
+            if (peg$silentFails === 0) { peg$fail(peg$c70); }
           }
         }
       } else {
@@ -1479,7 +1539,7 @@ module.exports = (function() {
           s3 = peg$parsews();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c68(s2);
+            s1 = peg$c71(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1504,11 +1564,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c46;
+          s2 = peg$c49;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c47); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1538,11 +1598,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c69;
+          s2 = peg$c72;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1572,11 +1632,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s2 = peg$c50;
+          s2 = peg$c53;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c54); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1606,11 +1666,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 125) {
-          s2 = peg$c71;
+          s2 = peg$c74;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c72); }
+          if (peg$silentFails === 0) { peg$fail(peg$c75); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1706,27 +1766,27 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c74.test(input.charAt(peg$currPos))) {
+      if (peg$c77.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c75); }
+        if (peg$silentFails === 0) { peg$fail(peg$c78); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c74.test(input.charAt(peg$currPos))) {
+        if (peg$c77.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c75); }
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
         }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c73); }
+        if (peg$silentFails === 0) { peg$fail(peg$c76); }
       }
 
       return s0;
@@ -1762,29 +1822,9 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c76) {
-        s1 = peg$c76;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c77); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c78();
-      }
-      s0 = s1;
-
-      return s0;
-    }
-
-    function peg$parsenull() {
-      var s0, s1;
-
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c79) {
+      if (input.substr(peg$currPos, 5) === peg$c79) {
         s1 = peg$c79;
-        peg$currPos += 4;
+        peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c80); }
@@ -1798,7 +1838,7 @@ module.exports = (function() {
       return s0;
     }
 
-    function peg$parsetrue() {
+    function peg$parsenull() {
       var s0, s1;
 
       s0 = peg$currPos;
@@ -1812,6 +1852,26 @@ module.exports = (function() {
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$c84();
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parsetrue() {
+      var s0, s1;
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4) === peg$c85) {
+        s1 = peg$c85;
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c87();
       }
       s0 = s1;
 
@@ -1834,7 +1894,7 @@ module.exports = (function() {
             s7 = peg$parsemember();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s5;
-              s6 = peg$c85(s3, s7);
+              s6 = peg$c88(s3, s7);
               s5 = s6;
             } else {
               peg$currPos = s5;
@@ -1852,7 +1912,7 @@ module.exports = (function() {
               s7 = peg$parsemember();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c85(s3, s7);
+                s6 = peg$c88(s3, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -1865,7 +1925,7 @@ module.exports = (function() {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c86(s3, s4);
+            s3 = peg$c89(s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1882,7 +1942,7 @@ module.exports = (function() {
           s3 = peg$parseend_object();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c87(s2);
+            s1 = peg$c90(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1911,7 +1971,7 @@ module.exports = (function() {
           s3 = peg$parsevalue();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c88(s1, s3);
+            s1 = peg$c91(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1945,7 +2005,7 @@ module.exports = (function() {
             s7 = peg$parsevalue();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s5;
-              s6 = peg$c89(s3, s7);
+              s6 = peg$c92(s3, s7);
               s5 = s6;
             } else {
               peg$currPos = s5;
@@ -1963,7 +2023,7 @@ module.exports = (function() {
               s7 = peg$parsevalue();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c89(s3, s7);
+                s6 = peg$c92(s3, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -1976,7 +2036,7 @@ module.exports = (function() {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c90(s3, s4);
+            s3 = peg$c93(s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1993,7 +2053,7 @@ module.exports = (function() {
           s3 = peg$parseend_array();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c91(s2);
+            s1 = peg$c94(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2034,7 +2094,7 @@ module.exports = (function() {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c93();
+              s1 = peg$c96();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2055,7 +2115,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c92); }
+        if (peg$silentFails === 0) { peg$fail(peg$c95); }
       }
 
       return s0;
@@ -2078,12 +2138,12 @@ module.exports = (function() {
     function peg$parsedigit1_9() {
       var s0;
 
-      if (peg$c94.test(input.charAt(peg$currPos))) {
+      if (peg$c97.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c95); }
+        if (peg$silentFails === 0) { peg$fail(peg$c98); }
       }
 
       return s0;
@@ -2092,12 +2152,12 @@ module.exports = (function() {
     function peg$parsee() {
       var s0;
 
-      if (peg$c96.test(input.charAt(peg$currPos))) {
+      if (peg$c99.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c100); }
       }
 
       return s0;
@@ -2211,11 +2271,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c98;
+        s0 = peg$c101;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        if (peg$silentFails === 0) { peg$fail(peg$c102); }
       }
 
       return s0;
@@ -2225,11 +2285,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 43) {
-        s0 = peg$c100;
+        s0 = peg$c103;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c101); }
+        if (peg$silentFails === 0) { peg$fail(peg$c104); }
       }
 
       return s0;
@@ -2239,11 +2299,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 48) {
-        s0 = peg$c102;
+        s0 = peg$c105;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
 
       return s0;
@@ -2266,7 +2326,7 @@ module.exports = (function() {
           s3 = peg$parsequotation_mark();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c105(s2);
+            s1 = peg$c108(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2283,7 +2343,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c104); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
 
       return s0;
@@ -2298,106 +2358,106 @@ module.exports = (function() {
         s1 = peg$parseescape();
         if (s1 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 34) {
-            s2 = peg$c106;
+            s2 = peg$c109;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c107); }
+            if (peg$silentFails === 0) { peg$fail(peg$c110); }
           }
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 92) {
-              s2 = peg$c108;
+              s2 = peg$c111;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c109); }
+              if (peg$silentFails === 0) { peg$fail(peg$c112); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 47) {
-                s2 = peg$c110;
+                s2 = peg$c113;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c111); }
+                if (peg$silentFails === 0) { peg$fail(peg$c114); }
               }
               if (s2 === peg$FAILED) {
                 s2 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 98) {
-                  s3 = peg$c112;
+                  s3 = peg$c115;
                   peg$currPos++;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c113); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c116); }
                 }
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s2;
-                  s3 = peg$c114();
+                  s3 = peg$c117();
                 }
                 s2 = s3;
                 if (s2 === peg$FAILED) {
                   s2 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 102) {
-                    s3 = peg$c115;
+                    s3 = peg$c118;
                     peg$currPos++;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c116); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c119); }
                   }
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s2;
-                    s3 = peg$c117();
+                    s3 = peg$c120();
                   }
                   s2 = s3;
                   if (s2 === peg$FAILED) {
                     s2 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 110) {
-                      s3 = peg$c118;
+                      s3 = peg$c121;
                       peg$currPos++;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c119); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c122); }
                     }
                     if (s3 !== peg$FAILED) {
                       peg$savedPos = s2;
-                      s3 = peg$c120();
+                      s3 = peg$c123();
                     }
                     s2 = s3;
                     if (s2 === peg$FAILED) {
                       s2 = peg$currPos;
                       if (input.charCodeAt(peg$currPos) === 114) {
-                        s3 = peg$c121;
+                        s3 = peg$c124;
                         peg$currPos++;
                       } else {
                         s3 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c122); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c125); }
                       }
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s2;
-                        s3 = peg$c123();
+                        s3 = peg$c126();
                       }
                       s2 = s3;
                       if (s2 === peg$FAILED) {
                         s2 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 116) {
-                          s3 = peg$c124;
+                          s3 = peg$c127;
                           peg$currPos++;
                         } else {
                           s3 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c125); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c128); }
                         }
                         if (s3 !== peg$FAILED) {
                           peg$savedPos = s2;
-                          s3 = peg$c126();
+                          s3 = peg$c129();
                         }
                         s2 = s3;
                         if (s2 === peg$FAILED) {
                           s2 = peg$currPos;
                           if (input.charCodeAt(peg$currPos) === 117) {
-                            s3 = peg$c127;
+                            s3 = peg$c130;
                             peg$currPos++;
                           } else {
                             s3 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c128); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c131); }
                           }
                           if (s3 !== peg$FAILED) {
                             s4 = peg$currPos;
@@ -2435,7 +2495,7 @@ module.exports = (function() {
                             }
                             if (s4 !== peg$FAILED) {
                               peg$savedPos = s2;
-                              s3 = peg$c129(s4);
+                              s3 = peg$c132(s4);
                               s2 = s3;
                             } else {
                               peg$currPos = s2;
@@ -2455,7 +2515,7 @@ module.exports = (function() {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c130(s2);
+            s1 = peg$c133(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2474,11 +2534,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 92) {
-        s0 = peg$c108;
+        s0 = peg$c111;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c109); }
+        if (peg$silentFails === 0) { peg$fail(peg$c112); }
       }
 
       return s0;
@@ -2488,11 +2548,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c106;
+        s0 = peg$c109;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c110); }
       }
 
       return s0;
@@ -2501,12 +2561,12 @@ module.exports = (function() {
     function peg$parseunescaped() {
       var s0;
 
-      if (peg$c131.test(input.charAt(peg$currPos))) {
+      if (peg$c134.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c132); }
+        if (peg$silentFails === 0) { peg$fail(peg$c135); }
       }
 
       return s0;
@@ -2515,12 +2575,12 @@ module.exports = (function() {
     function peg$parseDIGIT() {
       var s0;
 
-      if (peg$c48.test(input.charAt(peg$currPos))) {
+      if (peg$c51.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
 
       return s0;
@@ -2529,12 +2589,12 @@ module.exports = (function() {
     function peg$parseHEXDIG() {
       var s0;
 
-      if (peg$c133.test(input.charAt(peg$currPos))) {
+      if (peg$c136.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c134); }
+        if (peg$silentFails === 0) { peg$fail(peg$c137); }
       }
 
       return s0;
@@ -2576,6 +2636,18 @@ module.exports = (function() {
           nodes[nodeName].metadata=metadata;
         }
 
+      }
+
+      var anonymousIndexes = {};
+      var anonymousNodeNames = {};
+      parser.addAnonymousNode = function(comp, offset) {
+          if (!anonymousNodeNames[offset]) {
+              var componentName = comp.comp.replace(/[^a-zA-Z0-9]+/, "_");
+              anonymousIndexes[componentName] = (anonymousIndexes[componentName] || 0) + 1;
+              anonymousNodeNames[offset] = "_" + componentName + "_" + anonymousIndexes[componentName];
+              this.addNode(anonymousNodeNames[offset], comp);
+          }
+          return anonymousNodeNames[offset];
       }
 
       parser.getResult = function () {

--- a/lib/fbp.js
+++ b/lib/fbp.js
@@ -50,83 +50,89 @@ module.exports = (function() {
         peg$c11 = "OUTPORT=",
         peg$c12 = { type: "literal", value: "OUTPORT=", description: "\"OUTPORT=\"" },
         peg$c13 = function(node, port, pub) {return parser.registerOutports(node,port,pub)},
-        peg$c14 = /^[\n\r\u2028\u2029]/,
-        peg$c15 = { type: "class", value: "[\\n\\r\\u2028\\u2029]", description: "[\\n\\r\\u2028\\u2029]" },
-        peg$c16 = function(edges) {return parser.registerEdges(edges);},
-        peg$c17 = ",",
-        peg$c18 = { type: "literal", value: ",", description: "\",\"" },
-        peg$c19 = "#",
-        peg$c20 = { type: "literal", value: "#", description: "\"#\"" },
-        peg$c21 = "->",
-        peg$c22 = { type: "literal", value: "->", description: "\"->\"" },
-        peg$c23 = function(x, y) { return [x,y]; },
-        peg$c24 = function(x, proc, y) { return [{"tgt":makeInPort(proc, x)},{"src":makeOutPort(proc, y)}]; },
-        peg$c25 = function(proc, port) { return {"src":makeOutPort(proc, port)} },
-        peg$c26 = function(port, proc) { return {"tgt":makeInPort(proc, port)} },
-        peg$c27 = "'",
-        peg$c28 = { type: "literal", value: "'", description: "\"'\"" },
-        peg$c29 = function(iip) { return {"data":iip.join("")} },
-        peg$c30 = function(iip) { return {"data":iip} },
-        peg$c31 = function(name) { return name},
-        peg$c32 = /^[a-zA-Z_]/,
-        peg$c33 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
-        peg$c34 = /^[a-zA-Z0-9_\-]/,
-        peg$c35 = { type: "class", value: "[a-zA-Z0-9_\\-]", description: "[a-zA-Z0-9_\\-]" },
-        peg$c36 = function(name) { return makeName(name)},
-        peg$c37 = function(name, comp) { parser.addNode(name,comp); return name},
-        peg$c38 = function(comp) { return parser.addAnonymousNode(comp, location().start.offset) },
-        peg$c39 = "(",
-        peg$c40 = { type: "literal", value: "(", description: "\"(\"" },
-        peg$c41 = /^[a-zA-Z\/\-0-9_]/,
-        peg$c42 = { type: "class", value: "[a-zA-Z/\\-0-9_]", description: "[a-zA-Z/\\-0-9_]" },
-        peg$c43 = ")",
-        peg$c44 = { type: "literal", value: ")", description: "\")\"" },
-        peg$c45 = function(comp, meta) { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; },
-        peg$c46 = /^[a-zA-Z\/=_,0-9]/,
-        peg$c47 = { type: "class", value: "[a-zA-Z/=_,0-9]", description: "[a-zA-Z/=_,0-9]" },
-        peg$c48 = function(meta) {return meta},
-        peg$c49 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }},
-        peg$c50 = function(port) { return port; },
-        peg$c51 = /^[a-zA-Z.0-9_]/,
-        peg$c52 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
-        peg$c53 = function(portname) {return makeName(portname)},
-        peg$c54 = "[",
-        peg$c55 = { type: "literal", value: "[", description: "\"[\"" },
-        peg$c56 = /^[0-9]/,
-        peg$c57 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c58 = "]",
-        peg$c59 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c60 = function(portindex) {return parseInt(portindex.join(''))},
-        peg$c61 = /^[^\n\r\u2028\u2029]/,
-        peg$c62 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
-        peg$c63 = /^[\\]/,
-        peg$c64 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
-        peg$c65 = /^[']/,
-        peg$c66 = { type: "class", value: "[']", description: "[']" },
-        peg$c67 = function() { return "'"; },
-        peg$c68 = /^[^']/,
-        peg$c69 = { type: "class", value: "[^']", description: "[^']" },
-        peg$c70 = " ",
-        peg$c71 = { type: "literal", value: " ", description: "\" \"" },
-        peg$c72 = function(value) { return value; },
-        peg$c73 = "{",
-        peg$c74 = { type: "literal", value: "{", description: "\"{\"" },
-        peg$c75 = "}",
-        peg$c76 = { type: "literal", value: "}", description: "\"}\"" },
-        peg$c77 = { type: "other", description: "whitespace" },
-        peg$c78 = /^[ \t\n\r]/,
-        peg$c79 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
-        peg$c80 = "false",
-        peg$c81 = { type: "literal", value: "false", description: "\"false\"" },
-        peg$c82 = function() { return false; },
-        peg$c83 = "null",
-        peg$c84 = { type: "literal", value: "null", description: "\"null\"" },
-        peg$c85 = function() { return null;  },
-        peg$c86 = "true",
-        peg$c87 = { type: "literal", value: "true", description: "\"true\"" },
-        peg$c88 = function() { return true;  },
-        peg$c89 = function(head, m) { return m; },
-        peg$c90 = function(head, tail) {
+        peg$c14 = "DEFAULT_INPORT=",
+        peg$c15 = { type: "literal", value: "DEFAULT_INPORT=", description: "\"DEFAULT_INPORT=\"" },
+        peg$c16 = function(name) { defaultInPort = name},
+        peg$c17 = "DEFAULT_OUTPORT=",
+        peg$c18 = { type: "literal", value: "DEFAULT_OUTPORT=", description: "\"DEFAULT_OUTPORT=\"" },
+        peg$c19 = function(name) { defaultOutPort = name},
+        peg$c20 = /^[\n\r\u2028\u2029]/,
+        peg$c21 = { type: "class", value: "[\\n\\r\\u2028\\u2029]", description: "[\\n\\r\\u2028\\u2029]" },
+        peg$c22 = function(edges) {return parser.registerEdges(edges);},
+        peg$c23 = ",",
+        peg$c24 = { type: "literal", value: ",", description: "\",\"" },
+        peg$c25 = "#",
+        peg$c26 = { type: "literal", value: "#", description: "\"#\"" },
+        peg$c27 = "->",
+        peg$c28 = { type: "literal", value: "->", description: "\"->\"" },
+        peg$c29 = function(x, y) { return [x,y]; },
+        peg$c30 = function(x, proc, y) { return [{"tgt":makeInPort(proc, x)},{"src":makeOutPort(proc, y)}]; },
+        peg$c31 = function(proc, port) { return {"src":makeOutPort(proc, port)} },
+        peg$c32 = function(port, proc) { return {"tgt":makeInPort(proc, port)} },
+        peg$c33 = "'",
+        peg$c34 = { type: "literal", value: "'", description: "\"'\"" },
+        peg$c35 = function(iip) { return {"data":iip.join("")} },
+        peg$c36 = function(iip) { return {"data":iip} },
+        peg$c37 = function(name) { return name},
+        peg$c38 = /^[a-zA-Z_]/,
+        peg$c39 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
+        peg$c40 = /^[a-zA-Z0-9_\-]/,
+        peg$c41 = { type: "class", value: "[a-zA-Z0-9_\\-]", description: "[a-zA-Z0-9_\\-]" },
+        peg$c42 = function(name) { return makeName(name)},
+        peg$c43 = function(name, comp) { parser.addNode(name,comp); return name},
+        peg$c44 = function(comp) { return parser.addAnonymousNode(comp, location().start.offset) },
+        peg$c45 = "(",
+        peg$c46 = { type: "literal", value: "(", description: "\"(\"" },
+        peg$c47 = /^[a-zA-Z\/\-0-9_]/,
+        peg$c48 = { type: "class", value: "[a-zA-Z/\\-0-9_]", description: "[a-zA-Z/\\-0-9_]" },
+        peg$c49 = ")",
+        peg$c50 = { type: "literal", value: ")", description: "\")\"" },
+        peg$c51 = function(comp, meta) { var o = {}; comp ? o.comp = comp.join("") : o.comp = ''; meta ? o.meta = meta.join("").split(',') : null; return o; },
+        peg$c52 = /^[a-zA-Z\/=_,0-9]/,
+        peg$c53 = { type: "class", value: "[a-zA-Z/=_,0-9]", description: "[a-zA-Z/=_,0-9]" },
+        peg$c54 = function(meta) {return meta},
+        peg$c55 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }},
+        peg$c56 = function(port) { return port; },
+        peg$c57 = /^[a-zA-Z.0-9_]/,
+        peg$c58 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
+        peg$c59 = function(portname) {return makeName(portname)},
+        peg$c60 = "[",
+        peg$c61 = { type: "literal", value: "[", description: "\"[\"" },
+        peg$c62 = /^[0-9]/,
+        peg$c63 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c64 = "]",
+        peg$c65 = { type: "literal", value: "]", description: "\"]\"" },
+        peg$c66 = function(portindex) {return parseInt(portindex.join(''))},
+        peg$c67 = /^[^\n\r\u2028\u2029]/,
+        peg$c68 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
+        peg$c69 = /^[\\]/,
+        peg$c70 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
+        peg$c71 = /^[']/,
+        peg$c72 = { type: "class", value: "[']", description: "[']" },
+        peg$c73 = function() { return "'"; },
+        peg$c74 = /^[^']/,
+        peg$c75 = { type: "class", value: "[^']", description: "[^']" },
+        peg$c76 = " ",
+        peg$c77 = { type: "literal", value: " ", description: "\" \"" },
+        peg$c78 = function(value) { return value; },
+        peg$c79 = "{",
+        peg$c80 = { type: "literal", value: "{", description: "\"{\"" },
+        peg$c81 = "}",
+        peg$c82 = { type: "literal", value: "}", description: "\"}\"" },
+        peg$c83 = { type: "other", description: "whitespace" },
+        peg$c84 = /^[ \t\n\r]/,
+        peg$c85 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+        peg$c86 = "false",
+        peg$c87 = { type: "literal", value: "false", description: "\"false\"" },
+        peg$c88 = function() { return false; },
+        peg$c89 = "null",
+        peg$c90 = { type: "literal", value: "null", description: "\"null\"" },
+        peg$c91 = function() { return null;  },
+        peg$c92 = "true",
+        peg$c93 = { type: "literal", value: "true", description: "\"true\"" },
+        peg$c94 = function() { return true;  },
+        peg$c95 = function(head, m) { return m; },
+        peg$c96 = function(head, tail) {
                   var result = {}, i;
 
                   result[head.name] = head.value;
@@ -137,58 +143,58 @@ module.exports = (function() {
 
                   return result;
                 },
-        peg$c91 = function(members) { return members !== null ? members: {}; },
-        peg$c92 = function(name, value) {
+        peg$c97 = function(members) { return members !== null ? members: {}; },
+        peg$c98 = function(name, value) {
                 return { name: name, value: value };
               },
-        peg$c93 = function(head, v) { return v; },
-        peg$c94 = function(head, tail) { return [head].concat(tail); },
-        peg$c95 = function(values) { return values !== null ? values : []; },
-        peg$c96 = { type: "other", description: "number" },
-        peg$c97 = function() { return parseFloat(text()); },
-        peg$c98 = /^[1-9]/,
-        peg$c99 = { type: "class", value: "[1-9]", description: "[1-9]" },
-        peg$c100 = /^[eE]/,
-        peg$c101 = { type: "class", value: "[eE]", description: "[eE]" },
-        peg$c102 = "-",
-        peg$c103 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c104 = "+",
-        peg$c105 = { type: "literal", value: "+", description: "\"+\"" },
-        peg$c106 = "0",
-        peg$c107 = { type: "literal", value: "0", description: "\"0\"" },
-        peg$c108 = { type: "other", description: "string" },
-        peg$c109 = function(chars) { return chars.join(""); },
-        peg$c110 = "\"",
-        peg$c111 = { type: "literal", value: "\"", description: "\"\\\"\"" },
-        peg$c112 = "\\",
-        peg$c113 = { type: "literal", value: "\\", description: "\"\\\\\"" },
-        peg$c114 = "/",
-        peg$c115 = { type: "literal", value: "/", description: "\"/\"" },
-        peg$c116 = "b",
-        peg$c117 = { type: "literal", value: "b", description: "\"b\"" },
-        peg$c118 = function() { return "\b"; },
-        peg$c119 = "f",
-        peg$c120 = { type: "literal", value: "f", description: "\"f\"" },
-        peg$c121 = function() { return "\f"; },
-        peg$c122 = "n",
-        peg$c123 = { type: "literal", value: "n", description: "\"n\"" },
-        peg$c124 = function() { return "\n"; },
-        peg$c125 = "r",
-        peg$c126 = { type: "literal", value: "r", description: "\"r\"" },
-        peg$c127 = function() { return "\r"; },
-        peg$c128 = "t",
-        peg$c129 = { type: "literal", value: "t", description: "\"t\"" },
-        peg$c130 = function() { return "\t"; },
-        peg$c131 = "u",
-        peg$c132 = { type: "literal", value: "u", description: "\"u\"" },
-        peg$c133 = function(digits) {
+        peg$c99 = function(head, v) { return v; },
+        peg$c100 = function(head, tail) { return [head].concat(tail); },
+        peg$c101 = function(values) { return values !== null ? values : []; },
+        peg$c102 = { type: "other", description: "number" },
+        peg$c103 = function() { return parseFloat(text()); },
+        peg$c104 = /^[1-9]/,
+        peg$c105 = { type: "class", value: "[1-9]", description: "[1-9]" },
+        peg$c106 = /^[eE]/,
+        peg$c107 = { type: "class", value: "[eE]", description: "[eE]" },
+        peg$c108 = "-",
+        peg$c109 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c110 = "+",
+        peg$c111 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c112 = "0",
+        peg$c113 = { type: "literal", value: "0", description: "\"0\"" },
+        peg$c114 = { type: "other", description: "string" },
+        peg$c115 = function(chars) { return chars.join(""); },
+        peg$c116 = "\"",
+        peg$c117 = { type: "literal", value: "\"", description: "\"\\\"\"" },
+        peg$c118 = "\\",
+        peg$c119 = { type: "literal", value: "\\", description: "\"\\\\\"" },
+        peg$c120 = "/",
+        peg$c121 = { type: "literal", value: "/", description: "\"/\"" },
+        peg$c122 = "b",
+        peg$c123 = { type: "literal", value: "b", description: "\"b\"" },
+        peg$c124 = function() { return "\b"; },
+        peg$c125 = "f",
+        peg$c126 = { type: "literal", value: "f", description: "\"f\"" },
+        peg$c127 = function() { return "\f"; },
+        peg$c128 = "n",
+        peg$c129 = { type: "literal", value: "n", description: "\"n\"" },
+        peg$c130 = function() { return "\n"; },
+        peg$c131 = "r",
+        peg$c132 = { type: "literal", value: "r", description: "\"r\"" },
+        peg$c133 = function() { return "\r"; },
+        peg$c134 = "t",
+        peg$c135 = { type: "literal", value: "t", description: "\"t\"" },
+        peg$c136 = function() { return "\t"; },
+        peg$c137 = "u",
+        peg$c138 = { type: "literal", value: "u", description: "\"u\"" },
+        peg$c139 = function(digits) {
                     return String.fromCharCode(parseInt(digits, 16));
                   },
-        peg$c134 = function(sequence) { return sequence; },
-        peg$c135 = /^[^\0-\x1F"\\]/,
-        peg$c136 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
-        peg$c137 = /^[0-9a-f]/i,
-        peg$c138 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
+        peg$c140 = function(sequence) { return sequence; },
+        peg$c141 = /^[^\0-\x1F"\\]/,
+        peg$c142 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
+        peg$c143 = /^[0-9a-f]/i,
+        peg$c144 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -620,21 +626,40 @@ module.exports = (function() {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$parsecomment();
+            s1 = peg$parse_();
             if (s1 !== peg$FAILED) {
-              if (peg$c14.test(input.charAt(peg$currPos))) {
-                s2 = input.charAt(peg$currPos);
-                peg$currPos++;
+              if (input.substr(peg$currPos, 15) === peg$c14) {
+                s2 = peg$c14;
+                peg$currPos += 15;
               } else {
                 s2 = peg$FAILED;
                 if (peg$silentFails === 0) { peg$fail(peg$c15); }
               }
-              if (s2 === peg$FAILED) {
-                s2 = null;
-              }
               if (s2 !== peg$FAILED) {
-                s1 = [s1, s2];
-                s0 = s1;
+                s3 = peg$parseportName();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parse_();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parseLineTerminator();
+                    if (s5 === peg$FAILED) {
+                      s5 = null;
+                    }
+                    if (s5 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c16(s3);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -647,39 +672,25 @@ module.exports = (function() {
               s0 = peg$currPos;
               s1 = peg$parse_();
               if (s1 !== peg$FAILED) {
-                if (peg$c14.test(input.charAt(peg$currPos))) {
-                  s2 = input.charAt(peg$currPos);
-                  peg$currPos++;
+                if (input.substr(peg$currPos, 16) === peg$c17) {
+                  s2 = peg$c17;
+                  peg$currPos += 16;
                 } else {
                   s2 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c15); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s2 !== peg$FAILED) {
-                  s1 = [s1, s2];
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-              if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parse_();
-                if (s1 !== peg$FAILED) {
-                  s2 = peg$parseconnection();
-                  if (s2 !== peg$FAILED) {
-                    s3 = peg$parse_();
-                    if (s3 !== peg$FAILED) {
-                      s4 = peg$parseLineTerminator();
-                      if (s4 === peg$FAILED) {
-                        s4 = null;
+                  s3 = peg$parseportName();
+                  if (s3 !== peg$FAILED) {
+                    s4 = peg$parse_();
+                    if (s4 !== peg$FAILED) {
+                      s5 = peg$parseLineTerminator();
+                      if (s5 === peg$FAILED) {
+                        s5 = null;
                       }
-                      if (s4 !== peg$FAILED) {
+                      if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c16(s2);
+                        s1 = peg$c19(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -697,6 +708,91 @@ module.exports = (function() {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
                 }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+              if (s0 === peg$FAILED) {
+                s0 = peg$currPos;
+                s1 = peg$parsecomment();
+                if (s1 !== peg$FAILED) {
+                  if (peg$c20.test(input.charAt(peg$currPos))) {
+                    s2 = input.charAt(peg$currPos);
+                    peg$currPos++;
+                  } else {
+                    s2 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c21); }
+                  }
+                  if (s2 === peg$FAILED) {
+                    s2 = null;
+                  }
+                  if (s2 !== peg$FAILED) {
+                    s1 = [s1, s2];
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+                if (s0 === peg$FAILED) {
+                  s0 = peg$currPos;
+                  s1 = peg$parse_();
+                  if (s1 !== peg$FAILED) {
+                    if (peg$c20.test(input.charAt(peg$currPos))) {
+                      s2 = input.charAt(peg$currPos);
+                      peg$currPos++;
+                    } else {
+                      s2 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+                    }
+                    if (s2 !== peg$FAILED) {
+                      s1 = [s1, s2];
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$currPos;
+                    s1 = peg$parse_();
+                    if (s1 !== peg$FAILED) {
+                      s2 = peg$parseconnection();
+                      if (s2 !== peg$FAILED) {
+                        s3 = peg$parse_();
+                        if (s3 !== peg$FAILED) {
+                          s4 = peg$parseLineTerminator();
+                          if (s4 === peg$FAILED) {
+                            s4 = null;
+                          }
+                          if (s4 !== peg$FAILED) {
+                            peg$savedPos = s0;
+                            s1 = peg$c22(s2);
+                            s0 = s1;
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  }
+                }
               }
             }
           }
@@ -713,11 +809,11 @@ module.exports = (function() {
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s2 = peg$c17;
+          s2 = peg$c23;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c18); }
+          if (peg$silentFails === 0) { peg$fail(peg$c24); }
         }
         if (s2 === peg$FAILED) {
           s2 = null;
@@ -728,12 +824,12 @@ module.exports = (function() {
             s3 = null;
           }
           if (s3 !== peg$FAILED) {
-            if (peg$c14.test(input.charAt(peg$currPos))) {
+            if (peg$c20.test(input.charAt(peg$currPos))) {
               s4 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c15); }
+              if (peg$silentFails === 0) { peg$fail(peg$c21); }
             }
             if (s4 === peg$FAILED) {
               s4 = null;
@@ -768,11 +864,11 @@ module.exports = (function() {
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 35) {
-          s2 = peg$c19;
+          s2 = peg$c25;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c20); }
+          if (peg$silentFails === 0) { peg$fail(peg$c26); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
@@ -808,12 +904,12 @@ module.exports = (function() {
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c21) {
-            s3 = peg$c21;
+          if (input.substr(peg$currPos, 2) === peg$c27) {
+            s3 = peg$c27;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c22); }
+            if (peg$silentFails === 0) { peg$fail(peg$c28); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
@@ -821,7 +917,7 @@ module.exports = (function() {
               s5 = peg$parseconnection();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c23(s1, s5);
+                s1 = peg$c29(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -886,7 +982,7 @@ module.exports = (function() {
           s3 = peg$parse__port();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c24(s1, s2, s3);
+            s1 = peg$c30(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -915,7 +1011,7 @@ module.exports = (function() {
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c24(s1, s2, s3);
+              s1 = peg$c30(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -941,9 +1037,12 @@ module.exports = (function() {
       s1 = peg$parsenode();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__port();
+        if (s2 === peg$FAILED) {
+          s2 = null;
+        }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c25(s1, s2);
+          s1 = peg$c31(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -952,27 +1051,6 @@ module.exports = (function() {
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parsenodeWithComponent();
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse__port();
-          if (s2 === peg$FAILED) {
-            s2 = null;
-          }
-          if (s2 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c25(s1, s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
       }
 
       return s0;
@@ -983,11 +1061,14 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = peg$parseport__();
+      if (s1 === peg$FAILED) {
+        s1 = null;
+      }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsenode();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c26(s1, s2);
+          s1 = peg$c32(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -996,27 +1077,6 @@ module.exports = (function() {
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parseport__();
-        if (s1 === peg$FAILED) {
-          s1 = null;
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parsenodeWithComponent();
-          if (s2 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c26(s1, s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
       }
 
       return s0;
@@ -1027,11 +1087,11 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c27;
+        s1 = peg$c33;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c28); }
+        if (peg$silentFails === 0) { peg$fail(peg$c34); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -1042,15 +1102,15 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c27;
+            s3 = peg$c33;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c28); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c29(s2);
+            s1 = peg$c35(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1069,7 +1129,7 @@ module.exports = (function() {
         s1 = peg$parseJSON_text();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c30(s1);
+          s1 = peg$c36(s1);
         }
         s0 = s1;
       }
@@ -1084,7 +1144,7 @@ module.exports = (function() {
       s1 = peg$parsenodeNameAndComponent();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c31(s1);
+        s1 = peg$c37(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1092,7 +1152,7 @@ module.exports = (function() {
         s1 = peg$parsenodeName();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c31(s1);
+          s1 = peg$c37(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -1100,7 +1160,7 @@ module.exports = (function() {
           s1 = peg$parsenodeComponent();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c31(s1);
+            s1 = peg$c37(s1);
           }
           s0 = s1;
         }
@@ -1114,30 +1174,30 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (peg$c32.test(input.charAt(peg$currPos))) {
+      if (peg$c38.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c33); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c34.test(input.charAt(peg$currPos))) {
+        if (peg$c40.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          if (peg$silentFails === 0) { peg$fail(peg$c41); }
         }
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          if (peg$c34.test(input.charAt(peg$currPos))) {
+          if (peg$c40.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            if (peg$silentFails === 0) { peg$fail(peg$c41); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -1153,7 +1213,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c36(s1);
+        s1 = peg$c42(s1);
       }
       s0 = s1;
 
@@ -1169,7 +1229,7 @@ module.exports = (function() {
         s2 = peg$parsecomponent();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c37(s1, s2);
+          s1 = peg$c43(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1190,7 +1250,7 @@ module.exports = (function() {
       s1 = peg$parsecomponent();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c38(s1);
+        s1 = peg$c44(s1);
       }
       s0 = s1;
 
@@ -1213,29 +1273,29 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c39;
+        s1 = peg$c45;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c40); }
+        if (peg$silentFails === 0) { peg$fail(peg$c46); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c41.test(input.charAt(peg$currPos))) {
+        if (peg$c47.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c42); }
+          if (peg$silentFails === 0) { peg$fail(peg$c48); }
         }
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c41.test(input.charAt(peg$currPos))) {
+          if (peg$c47.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c42); }
+            if (peg$silentFails === 0) { peg$fail(peg$c48); }
           }
         }
         if (s2 === peg$FAILED) {
@@ -1248,15 +1308,15 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s4 = peg$c43;
+              s4 = peg$c49;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+              if (peg$silentFails === 0) { peg$fail(peg$c50); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c45(s2, s3);
+              s1 = peg$c51(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1291,22 +1351,22 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c46.test(input.charAt(peg$currPos))) {
+        if (peg$c52.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c47); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c46.test(input.charAt(peg$currPos))) {
+            if (peg$c52.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c47); }
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
             }
           }
         } else {
@@ -1314,7 +1374,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c48(s2);
+          s1 = peg$c54(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1340,7 +1400,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c49(s1, s2);
+          s1 = peg$c55(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1363,7 +1423,7 @@ module.exports = (function() {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c50(s1);
+          s1 = peg$c56(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1386,7 +1446,7 @@ module.exports = (function() {
         s2 = peg$parseport();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c50(s2);
+          s1 = peg$c56(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1405,30 +1465,30 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (peg$c32.test(input.charAt(peg$currPos))) {
+      if (peg$c38.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c33); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c51.test(input.charAt(peg$currPos))) {
+        if (peg$c57.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c52); }
+          if (peg$silentFails === 0) { peg$fail(peg$c58); }
         }
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          if (peg$c51.test(input.charAt(peg$currPos))) {
+          if (peg$c57.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c52); }
+            if (peg$silentFails === 0) { peg$fail(peg$c58); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -1444,7 +1504,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c53(s1);
+        s1 = peg$c59(s1);
       }
       s0 = s1;
 
@@ -1456,30 +1516,30 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c54;
+        s1 = peg$c60;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c56.test(input.charAt(peg$currPos))) {
+        if (peg$c62.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c57); }
+          if (peg$silentFails === 0) { peg$fail(peg$c63); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c56.test(input.charAt(peg$currPos))) {
+            if (peg$c62.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c57); }
+              if (peg$silentFails === 0) { peg$fail(peg$c63); }
             }
           }
         } else {
@@ -1487,15 +1547,15 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 93) {
-            s3 = peg$c58;
+            s3 = peg$c64;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c59); }
+            if (peg$silentFails === 0) { peg$fail(peg$c65); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c60(s2);
+            s1 = peg$c66(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1516,12 +1576,12 @@ module.exports = (function() {
     function peg$parseanychar() {
       var s0;
 
-      if (peg$c61.test(input.charAt(peg$currPos))) {
+      if (peg$c67.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c62); }
+        if (peg$silentFails === 0) { peg$fail(peg$c68); }
       }
 
       return s0;
@@ -1531,24 +1591,24 @@ module.exports = (function() {
       var s0, s1, s2;
 
       s0 = peg$currPos;
-      if (peg$c63.test(input.charAt(peg$currPos))) {
+      if (peg$c69.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+        if (peg$silentFails === 0) { peg$fail(peg$c70); }
       }
       if (s1 !== peg$FAILED) {
-        if (peg$c65.test(input.charAt(peg$currPos))) {
+        if (peg$c71.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c72); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c67();
+          s1 = peg$c73();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1559,12 +1619,12 @@ module.exports = (function() {
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
-        if (peg$c68.test(input.charAt(peg$currPos))) {
+        if (peg$c74.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+          if (peg$silentFails === 0) { peg$fail(peg$c75); }
         }
       }
 
@@ -1576,20 +1636,20 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c70;
+        s1 = peg$c76;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c71); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
         if (input.charCodeAt(peg$currPos) === 32) {
-          s1 = peg$c70;
+          s1 = peg$c76;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c71); }
+          if (peg$silentFails === 0) { peg$fail(peg$c77); }
         }
       }
       if (s0 === peg$FAILED) {
@@ -1604,21 +1664,21 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c70;
+        s1 = peg$c76;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c71); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
           if (input.charCodeAt(peg$currPos) === 32) {
-            s1 = peg$c70;
+            s1 = peg$c76;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c71); }
+            if (peg$silentFails === 0) { peg$fail(peg$c77); }
           }
         }
       } else {
@@ -1639,7 +1699,7 @@ module.exports = (function() {
           s3 = peg$parsews();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c72(s2);
+            s1 = peg$c78(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1664,11 +1724,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c54;
+          s2 = peg$c60;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1698,11 +1758,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c73;
+          s2 = peg$c79;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1732,11 +1792,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s2 = peg$c58;
+          s2 = peg$c64;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c59); }
+          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1766,11 +1826,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 125) {
-          s2 = peg$c75;
+          s2 = peg$c81;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1834,11 +1894,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s2 = peg$c17;
+          s2 = peg$c23;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c18); }
+          if (peg$silentFails === 0) { peg$fail(peg$c24); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1866,27 +1926,27 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c78.test(input.charAt(peg$currPos))) {
+      if (peg$c84.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c79); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c78.test(input.charAt(peg$currPos))) {
+        if (peg$c84.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c77); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
 
       return s0;
@@ -1922,16 +1982,16 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c80) {
-        s1 = peg$c80;
+      if (input.substr(peg$currPos, 5) === peg$c86) {
+        s1 = peg$c86;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c82();
+        s1 = peg$c88();
       }
       s0 = s1;
 
@@ -1942,16 +2002,16 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c83) {
-        s1 = peg$c83;
+      if (input.substr(peg$currPos, 4) === peg$c89) {
+        s1 = peg$c89;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c90); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c85();
+        s1 = peg$c91();
       }
       s0 = s1;
 
@@ -1962,16 +2022,16 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c86) {
-        s1 = peg$c86;
+      if (input.substr(peg$currPos, 4) === peg$c92) {
+        s1 = peg$c92;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c87); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c88();
+        s1 = peg$c94();
       }
       s0 = s1;
 
@@ -1994,7 +2054,7 @@ module.exports = (function() {
             s7 = peg$parsemember();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s5;
-              s6 = peg$c89(s3, s7);
+              s6 = peg$c95(s3, s7);
               s5 = s6;
             } else {
               peg$currPos = s5;
@@ -2012,7 +2072,7 @@ module.exports = (function() {
               s7 = peg$parsemember();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c89(s3, s7);
+                s6 = peg$c95(s3, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -2025,7 +2085,7 @@ module.exports = (function() {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c90(s3, s4);
+            s3 = peg$c96(s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2042,7 +2102,7 @@ module.exports = (function() {
           s3 = peg$parseend_object();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c91(s2);
+            s1 = peg$c97(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2071,7 +2131,7 @@ module.exports = (function() {
           s3 = peg$parsevalue();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c92(s1, s3);
+            s1 = peg$c98(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2105,7 +2165,7 @@ module.exports = (function() {
             s7 = peg$parsevalue();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s5;
-              s6 = peg$c93(s3, s7);
+              s6 = peg$c99(s3, s7);
               s5 = s6;
             } else {
               peg$currPos = s5;
@@ -2123,7 +2183,7 @@ module.exports = (function() {
               s7 = peg$parsevalue();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c93(s3, s7);
+                s6 = peg$c99(s3, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -2136,7 +2196,7 @@ module.exports = (function() {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c94(s3, s4);
+            s3 = peg$c100(s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2153,7 +2213,7 @@ module.exports = (function() {
           s3 = peg$parseend_array();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c95(s2);
+            s1 = peg$c101(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2194,7 +2254,7 @@ module.exports = (function() {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c97();
+              s1 = peg$c103();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2215,7 +2275,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c96); }
+        if (peg$silentFails === 0) { peg$fail(peg$c102); }
       }
 
       return s0;
@@ -2238,12 +2298,12 @@ module.exports = (function() {
     function peg$parsedigit1_9() {
       var s0;
 
-      if (peg$c98.test(input.charAt(peg$currPos))) {
+      if (peg$c104.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        if (peg$silentFails === 0) { peg$fail(peg$c105); }
       }
 
       return s0;
@@ -2252,12 +2312,12 @@ module.exports = (function() {
     function peg$parsee() {
       var s0;
 
-      if (peg$c100.test(input.charAt(peg$currPos))) {
+      if (peg$c106.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c101); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
 
       return s0;
@@ -2371,11 +2431,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c102;
+        s0 = peg$c108;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
 
       return s0;
@@ -2385,11 +2445,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 43) {
-        s0 = peg$c104;
+        s0 = peg$c110;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
       }
 
       return s0;
@@ -2399,11 +2459,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 48) {
-        s0 = peg$c106;
+        s0 = peg$c112;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
 
       return s0;
@@ -2426,7 +2486,7 @@ module.exports = (function() {
           s3 = peg$parsequotation_mark();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c109(s2);
+            s1 = peg$c115(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2443,7 +2503,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c108); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
 
       return s0;
@@ -2458,106 +2518,106 @@ module.exports = (function() {
         s1 = peg$parseescape();
         if (s1 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 34) {
-            s2 = peg$c110;
+            s2 = peg$c116;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c111); }
+            if (peg$silentFails === 0) { peg$fail(peg$c117); }
           }
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 92) {
-              s2 = peg$c112;
+              s2 = peg$c118;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c113); }
+              if (peg$silentFails === 0) { peg$fail(peg$c119); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 47) {
-                s2 = peg$c114;
+                s2 = peg$c120;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c115); }
+                if (peg$silentFails === 0) { peg$fail(peg$c121); }
               }
               if (s2 === peg$FAILED) {
                 s2 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 98) {
-                  s3 = peg$c116;
+                  s3 = peg$c122;
                   peg$currPos++;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c117); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c123); }
                 }
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s2;
-                  s3 = peg$c118();
+                  s3 = peg$c124();
                 }
                 s2 = s3;
                 if (s2 === peg$FAILED) {
                   s2 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 102) {
-                    s3 = peg$c119;
+                    s3 = peg$c125;
                     peg$currPos++;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c126); }
                   }
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s2;
-                    s3 = peg$c121();
+                    s3 = peg$c127();
                   }
                   s2 = s3;
                   if (s2 === peg$FAILED) {
                     s2 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 110) {
-                      s3 = peg$c122;
+                      s3 = peg$c128;
                       peg$currPos++;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c123); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c129); }
                     }
                     if (s3 !== peg$FAILED) {
                       peg$savedPos = s2;
-                      s3 = peg$c124();
+                      s3 = peg$c130();
                     }
                     s2 = s3;
                     if (s2 === peg$FAILED) {
                       s2 = peg$currPos;
                       if (input.charCodeAt(peg$currPos) === 114) {
-                        s3 = peg$c125;
+                        s3 = peg$c131;
                         peg$currPos++;
                       } else {
                         s3 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c126); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c132); }
                       }
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s2;
-                        s3 = peg$c127();
+                        s3 = peg$c133();
                       }
                       s2 = s3;
                       if (s2 === peg$FAILED) {
                         s2 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 116) {
-                          s3 = peg$c128;
+                          s3 = peg$c134;
                           peg$currPos++;
                         } else {
                           s3 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c129); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c135); }
                         }
                         if (s3 !== peg$FAILED) {
                           peg$savedPos = s2;
-                          s3 = peg$c130();
+                          s3 = peg$c136();
                         }
                         s2 = s3;
                         if (s2 === peg$FAILED) {
                           s2 = peg$currPos;
                           if (input.charCodeAt(peg$currPos) === 117) {
-                            s3 = peg$c131;
+                            s3 = peg$c137;
                             peg$currPos++;
                           } else {
                             s3 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c132); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c138); }
                           }
                           if (s3 !== peg$FAILED) {
                             s4 = peg$currPos;
@@ -2595,7 +2655,7 @@ module.exports = (function() {
                             }
                             if (s4 !== peg$FAILED) {
                               peg$savedPos = s2;
-                              s3 = peg$c133(s4);
+                              s3 = peg$c139(s4);
                               s2 = s3;
                             } else {
                               peg$currPos = s2;
@@ -2615,7 +2675,7 @@ module.exports = (function() {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c134(s2);
+            s1 = peg$c140(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2634,11 +2694,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 92) {
-        s0 = peg$c112;
+        s0 = peg$c118;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c113); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
 
       return s0;
@@ -2648,11 +2708,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c110;
+        s0 = peg$c116;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
 
       return s0;
@@ -2661,12 +2721,12 @@ module.exports = (function() {
     function peg$parseunescaped() {
       var s0;
 
-      if (peg$c135.test(input.charAt(peg$currPos))) {
+      if (peg$c141.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c136); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
 
       return s0;
@@ -2675,12 +2735,12 @@ module.exports = (function() {
     function peg$parseDIGIT() {
       var s0;
 
-      if (peg$c56.test(input.charAt(peg$currPos))) {
+      if (peg$c62.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        if (peg$silentFails === 0) { peg$fail(peg$c63); }
       }
 
       return s0;
@@ -2689,12 +2749,12 @@ module.exports = (function() {
     function peg$parseHEXDIG() {
       var s0;
 
-      if (peg$c137.test(input.charAt(peg$currPos))) {
+      if (peg$c143.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c138); }
+        if (peg$silentFails === 0) { peg$fail(peg$c144); }
       }
 
       return s0;
@@ -2702,6 +2762,8 @@ module.exports = (function() {
 
 
       var parser, edges, nodes;
+
+      var defaultInPort = "IN", defaultOutPort = "OUT";
 
       parser = this;
       delete parser.exports;
@@ -2858,7 +2920,13 @@ module.exports = (function() {
       }
 
       function makePort(process, port, defaultPort) {
-        var p = { process: process, port: port ? port.port : defaultPort };
+        if (!options.caseSensitive) {
+          defaultPort = defaultPort.toLowerCase()
+        }
+        var p = {
+            process: process,
+            port: port ? port.port : defaultPort
+        };
         if (port && port.index != null) {
             p.index = port.index;
         }
@@ -2866,10 +2934,10 @@ module.exports = (function() {
     }
 
       function makeInPort(process, port) {
-          return makePort(process, port, "IN");
+          return makePort(process, port, defaultInPort);
       }
       function makeOutPort(process, port) {
-          return makePort(process, port, "OUT");
+          return makePort(process, port, defaultOutPort);
       }
 
 

--- a/lib/fbp.js
+++ b/lib/fbp.js
@@ -2893,10 +2893,11 @@ module.exports = (function() {
       }
 
       parser.registerEdges = function (edges) {
-
-        edges.forEach(function (o, i) {
-          parser.edges.push(o);
-        });
+        if (Array.isArray(edges)) {
+          edges.forEach(function (o, i) {
+            parser.edges.push(o);
+          });
+        }
       }
 
       parser.processEdges = function () {

--- a/lib/fbp.js
+++ b/lib/fbp.js
@@ -62,11 +62,11 @@ module.exports = (function() {
         peg$c23 = function(x, y) { return [x,y]; },
         peg$c24 = function(x, proc, y) { return [{"tgt":makeInPort(proc, x)},{"src":makeOutPort(proc, y)}]; },
         peg$c25 = function(proc, port) { return {"src":makeOutPort(proc, port)} },
-        peg$c26 = "'",
-        peg$c27 = { type: "literal", value: "'", description: "\"'\"" },
-        peg$c28 = function(iip) { return {"data":iip.join("")} },
-        peg$c29 = function(iip) { return {"data":iip} },
-        peg$c30 = function(port, proc) { return {"tgt":makeInPort(proc, port)} },
+        peg$c26 = function(port, proc) { return {"tgt":makeInPort(proc, port)} },
+        peg$c27 = "'",
+        peg$c28 = { type: "literal", value: "'", description: "\"'\"" },
+        peg$c29 = function(iip) { return {"data":iip.join("")} },
+        peg$c30 = function(iip) { return {"data":iip} },
         peg$c31 = function(name) { return name},
         peg$c32 = /^[a-zA-Z_]/,
         peg$c33 = { type: "class", value: "[a-zA-Z_]", description: "[a-zA-Z_]" },
@@ -85,47 +85,48 @@ module.exports = (function() {
         peg$c46 = /^[a-zA-Z\/=_,0-9]/,
         peg$c47 = { type: "class", value: "[a-zA-Z/=_,0-9]", description: "[a-zA-Z/=_,0-9]" },
         peg$c48 = function(meta) {return meta},
-        peg$c49 = "[",
-        peg$c50 = { type: "literal", value: "[", description: "\"[\"" },
-        peg$c51 = /^[0-9]/,
-        peg$c52 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c53 = "]",
-        peg$c54 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c55 = function(portindex) {return parseInt(portindex.join(''))},
-        peg$c56 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }},
-        peg$c57 = /^[a-zA-Z.0-9_]/,
-        peg$c58 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
-        peg$c59 = function(portname) {return makeName(portname)},
-        peg$c60 = /^[^\n\r\u2028\u2029]/,
-        peg$c61 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
-        peg$c62 = /^[\\]/,
-        peg$c63 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
-        peg$c64 = /^[']/,
-        peg$c65 = { type: "class", value: "[']", description: "[']" },
-        peg$c66 = function() { return "'"; },
-        peg$c67 = /^[^']/,
-        peg$c68 = { type: "class", value: "[^']", description: "[^']" },
-        peg$c69 = " ",
-        peg$c70 = { type: "literal", value: " ", description: "\" \"" },
-        peg$c71 = function(value) { return value; },
-        peg$c72 = "{",
-        peg$c73 = { type: "literal", value: "{", description: "\"{\"" },
-        peg$c74 = "}",
-        peg$c75 = { type: "literal", value: "}", description: "\"}\"" },
-        peg$c76 = { type: "other", description: "whitespace" },
-        peg$c77 = /^[ \t\n\r]/,
-        peg$c78 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
-        peg$c79 = "false",
-        peg$c80 = { type: "literal", value: "false", description: "\"false\"" },
-        peg$c81 = function() { return false; },
-        peg$c82 = "null",
-        peg$c83 = { type: "literal", value: "null", description: "\"null\"" },
-        peg$c84 = function() { return null;  },
-        peg$c85 = "true",
-        peg$c86 = { type: "literal", value: "true", description: "\"true\"" },
-        peg$c87 = function() { return true;  },
-        peg$c88 = function(head, m) { return m; },
-        peg$c89 = function(head, tail) {
+        peg$c49 = function(portname, portindex) {return { port: options.caseSensitive? portname : portname.toLowerCase(), index: portindex != null ? portindex : undefined }},
+        peg$c50 = function(port) { return port; },
+        peg$c51 = /^[a-zA-Z.0-9_]/,
+        peg$c52 = { type: "class", value: "[a-zA-Z.0-9_]", description: "[a-zA-Z.0-9_]" },
+        peg$c53 = function(portname) {return makeName(portname)},
+        peg$c54 = "[",
+        peg$c55 = { type: "literal", value: "[", description: "\"[\"" },
+        peg$c56 = /^[0-9]/,
+        peg$c57 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c58 = "]",
+        peg$c59 = { type: "literal", value: "]", description: "\"]\"" },
+        peg$c60 = function(portindex) {return parseInt(portindex.join(''))},
+        peg$c61 = /^[^\n\r\u2028\u2029]/,
+        peg$c62 = { type: "class", value: "[^\\n\\r\\u2028\\u2029]", description: "[^\\n\\r\\u2028\\u2029]" },
+        peg$c63 = /^[\\]/,
+        peg$c64 = { type: "class", value: "[\\\\]", description: "[\\\\]" },
+        peg$c65 = /^[']/,
+        peg$c66 = { type: "class", value: "[']", description: "[']" },
+        peg$c67 = function() { return "'"; },
+        peg$c68 = /^[^']/,
+        peg$c69 = { type: "class", value: "[^']", description: "[^']" },
+        peg$c70 = " ",
+        peg$c71 = { type: "literal", value: " ", description: "\" \"" },
+        peg$c72 = function(value) { return value; },
+        peg$c73 = "{",
+        peg$c74 = { type: "literal", value: "{", description: "\"{\"" },
+        peg$c75 = "}",
+        peg$c76 = { type: "literal", value: "}", description: "\"}\"" },
+        peg$c77 = { type: "other", description: "whitespace" },
+        peg$c78 = /^[ \t\n\r]/,
+        peg$c79 = { type: "class", value: "[ \\t\\n\\r]", description: "[ \\t\\n\\r]" },
+        peg$c80 = "false",
+        peg$c81 = { type: "literal", value: "false", description: "\"false\"" },
+        peg$c82 = function() { return false; },
+        peg$c83 = "null",
+        peg$c84 = { type: "literal", value: "null", description: "\"null\"" },
+        peg$c85 = function() { return null;  },
+        peg$c86 = "true",
+        peg$c87 = { type: "literal", value: "true", description: "\"true\"" },
+        peg$c88 = function() { return true;  },
+        peg$c89 = function(head, m) { return m; },
+        peg$c90 = function(head, tail) {
                   var result = {}, i;
 
                   result[head.name] = head.value;
@@ -136,58 +137,58 @@ module.exports = (function() {
 
                   return result;
                 },
-        peg$c90 = function(members) { return members !== null ? members: {}; },
-        peg$c91 = function(name, value) {
+        peg$c91 = function(members) { return members !== null ? members: {}; },
+        peg$c92 = function(name, value) {
                 return { name: name, value: value };
               },
-        peg$c92 = function(head, v) { return v; },
-        peg$c93 = function(head, tail) { return [head].concat(tail); },
-        peg$c94 = function(values) { return values !== null ? values : []; },
-        peg$c95 = { type: "other", description: "number" },
-        peg$c96 = function() { return parseFloat(text()); },
-        peg$c97 = /^[1-9]/,
-        peg$c98 = { type: "class", value: "[1-9]", description: "[1-9]" },
-        peg$c99 = /^[eE]/,
-        peg$c100 = { type: "class", value: "[eE]", description: "[eE]" },
-        peg$c101 = "-",
-        peg$c102 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c103 = "+",
-        peg$c104 = { type: "literal", value: "+", description: "\"+\"" },
-        peg$c105 = "0",
-        peg$c106 = { type: "literal", value: "0", description: "\"0\"" },
-        peg$c107 = { type: "other", description: "string" },
-        peg$c108 = function(chars) { return chars.join(""); },
-        peg$c109 = "\"",
-        peg$c110 = { type: "literal", value: "\"", description: "\"\\\"\"" },
-        peg$c111 = "\\",
-        peg$c112 = { type: "literal", value: "\\", description: "\"\\\\\"" },
-        peg$c113 = "/",
-        peg$c114 = { type: "literal", value: "/", description: "\"/\"" },
-        peg$c115 = "b",
-        peg$c116 = { type: "literal", value: "b", description: "\"b\"" },
-        peg$c117 = function() { return "\b"; },
-        peg$c118 = "f",
-        peg$c119 = { type: "literal", value: "f", description: "\"f\"" },
-        peg$c120 = function() { return "\f"; },
-        peg$c121 = "n",
-        peg$c122 = { type: "literal", value: "n", description: "\"n\"" },
-        peg$c123 = function() { return "\n"; },
-        peg$c124 = "r",
-        peg$c125 = { type: "literal", value: "r", description: "\"r\"" },
-        peg$c126 = function() { return "\r"; },
-        peg$c127 = "t",
-        peg$c128 = { type: "literal", value: "t", description: "\"t\"" },
-        peg$c129 = function() { return "\t"; },
-        peg$c130 = "u",
-        peg$c131 = { type: "literal", value: "u", description: "\"u\"" },
-        peg$c132 = function(digits) {
+        peg$c93 = function(head, v) { return v; },
+        peg$c94 = function(head, tail) { return [head].concat(tail); },
+        peg$c95 = function(values) { return values !== null ? values : []; },
+        peg$c96 = { type: "other", description: "number" },
+        peg$c97 = function() { return parseFloat(text()); },
+        peg$c98 = /^[1-9]/,
+        peg$c99 = { type: "class", value: "[1-9]", description: "[1-9]" },
+        peg$c100 = /^[eE]/,
+        peg$c101 = { type: "class", value: "[eE]", description: "[eE]" },
+        peg$c102 = "-",
+        peg$c103 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c104 = "+",
+        peg$c105 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c106 = "0",
+        peg$c107 = { type: "literal", value: "0", description: "\"0\"" },
+        peg$c108 = { type: "other", description: "string" },
+        peg$c109 = function(chars) { return chars.join(""); },
+        peg$c110 = "\"",
+        peg$c111 = { type: "literal", value: "\"", description: "\"\\\"\"" },
+        peg$c112 = "\\",
+        peg$c113 = { type: "literal", value: "\\", description: "\"\\\\\"" },
+        peg$c114 = "/",
+        peg$c115 = { type: "literal", value: "/", description: "\"/\"" },
+        peg$c116 = "b",
+        peg$c117 = { type: "literal", value: "b", description: "\"b\"" },
+        peg$c118 = function() { return "\b"; },
+        peg$c119 = "f",
+        peg$c120 = { type: "literal", value: "f", description: "\"f\"" },
+        peg$c121 = function() { return "\f"; },
+        peg$c122 = "n",
+        peg$c123 = { type: "literal", value: "n", description: "\"n\"" },
+        peg$c124 = function() { return "\n"; },
+        peg$c125 = "r",
+        peg$c126 = { type: "literal", value: "r", description: "\"r\"" },
+        peg$c127 = function() { return "\r"; },
+        peg$c128 = "t",
+        peg$c129 = { type: "literal", value: "t", description: "\"t\"" },
+        peg$c130 = function() { return "\t"; },
+        peg$c131 = "u",
+        peg$c132 = { type: "literal", value: "u", description: "\"u\"" },
+        peg$c133 = function(digits) {
                     return String.fromCharCode(parseInt(digits, 16));
                   },
-        peg$c133 = function(sequence) { return sequence; },
-        peg$c134 = /^[^\0-\x1F"\\]/,
-        peg$c135 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
-        peg$c136 = /^[0-9a-f]/i,
-        peg$c137 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
+        peg$c134 = function(sequence) { return sequence; },
+        peg$c135 = /^[^\0-\x1F"\\]/,
+        peg$c136 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
+        peg$c137 = /^[0-9a-f]/i,
+        peg$c138 = { type: "class", value: "[0-9a-f]i", description: "[0-9a-f]i" },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -875,58 +876,17 @@ module.exports = (function() {
     }
 
     function peg$parsebridge() {
-      var s0, s1, s2, s3, s4, s5;
-
-      s0 = peg$currPos;
-      s1 = peg$parseport();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse_();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parsenode();
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse_();
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parseport();
-              if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c24(s1, s3, s5);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      return s0;
-    }
-
-    function peg$parseoutport() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      s1 = peg$parsenode();
+      s1 = peg$parseport__();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parse_();
+        s2 = peg$parsenode();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseport();
+          s3 = peg$parse__port();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c25(s1, s3);
+            s1 = peg$c24(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -940,6 +900,124 @@ module.exports = (function() {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseport__();
+        if (s1 === peg$FAILED) {
+          s1 = null;
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsenodeWithComponent();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parse__port();
+            if (s3 === peg$FAILED) {
+              s3 = null;
+            }
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c24(s1, s2, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
+
+      return s0;
+    }
+
+    function peg$parseoutport() {
+      var s0, s1, s2;
+
+      s0 = peg$currPos;
+      s1 = peg$parsenode();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse__port();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c25(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsenodeWithComponent();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parse__port();
+          if (s2 === peg$FAILED) {
+            s2 = null;
+          }
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c25(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
+
+      return s0;
+    }
+
+    function peg$parseinport() {
+      var s0, s1, s2;
+
+      s0 = peg$currPos;
+      s1 = peg$parseport__();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsenode();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c26(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseport__();
+        if (s1 === peg$FAILED) {
+          s1 = null;
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsenodeWithComponent();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c26(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
 
       return s0;
     }
@@ -949,11 +1027,11 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c26;
+        s1 = peg$c27;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c27); }
+        if (peg$silentFails === 0) { peg$fail(peg$c28); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -964,15 +1042,15 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c26;
+            s3 = peg$c27;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c27); }
+            if (peg$silentFails === 0) { peg$fail(peg$c28); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c28(s2);
+            s1 = peg$c29(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -991,38 +1069,9 @@ module.exports = (function() {
         s1 = peg$parseJSON_text();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c29(s1);
+          s1 = peg$c30(s1);
         }
         s0 = s1;
-      }
-
-      return s0;
-    }
-
-    function peg$parseinport() {
-      var s0, s1, s2, s3;
-
-      s0 = peg$currPos;
-      s1 = peg$parseport();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse_();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parsenode();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c30(s1, s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
       }
 
       return s0;
@@ -1148,6 +1197,17 @@ module.exports = (function() {
       return s0;
     }
 
+    function peg$parsenodeWithComponent() {
+      var s0;
+
+      s0 = peg$parsenodeNameAndComponent();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parsenodeComponent();
+      }
+
+      return s0;
+    }
+
     function peg$parsecomponent() {
       var s0, s1, s2, s3, s4;
 
@@ -1268,56 +1328,20 @@ module.exports = (function() {
       return s0;
     }
 
-    function peg$parseportIndex() {
-      var s0, s1, s2, s3;
+    function peg$parseport() {
+      var s0, s1, s2;
 
       s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c49;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
-      }
+      s1 = peg$parseportName();
       if (s1 !== peg$FAILED) {
-        s2 = [];
-        if (peg$c51.test(input.charAt(peg$currPos))) {
-          s3 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c52); }
-        }
-        if (s3 !== peg$FAILED) {
-          while (s3 !== peg$FAILED) {
-            s2.push(s3);
-            if (peg$c51.test(input.charAt(peg$currPos))) {
-              s3 = input.charAt(peg$currPos);
-              peg$currPos++;
-            } else {
-              s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c52); }
-            }
-          }
-        } else {
-          s2 = peg$FAILED;
+        s2 = peg$parseportIndex();
+        if (s2 === peg$FAILED) {
+          s2 = null;
         }
         if (s2 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 93) {
-            s3 = peg$c53;
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
-          }
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c55(s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
+          peg$savedPos = s0;
+          s1 = peg$c49(s1, s2);
+          s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1330,26 +1354,40 @@ module.exports = (function() {
       return s0;
     }
 
-    function peg$parseport() {
-      var s0, s1, s2, s3;
+    function peg$parseport__() {
+      var s0, s1, s2;
 
       s0 = peg$currPos;
-      s1 = peg$parseportName();
+      s1 = peg$parseport();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseportIndex();
-        if (s2 === peg$FAILED) {
-          s2 = null;
-        }
+        s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parse__();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c56(s1, s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
+          peg$savedPos = s0;
+          s1 = peg$c50(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parse__port() {
+      var s0, s1, s2;
+
+      s0 = peg$currPos;
+      s1 = peg$parse__();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseport();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c50(s2);
+          s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1376,21 +1414,21 @@ module.exports = (function() {
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        if (peg$c57.test(input.charAt(peg$currPos))) {
+        if (peg$c51.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c58); }
+          if (peg$silentFails === 0) { peg$fail(peg$c52); }
         }
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          if (peg$c57.test(input.charAt(peg$currPos))) {
+          if (peg$c51.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c58); }
+            if (peg$silentFails === 0) { peg$fail(peg$c52); }
           }
         }
         if (s3 !== peg$FAILED) {
@@ -1406,9 +1444,71 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c59(s1);
+        s1 = peg$c53(s1);
       }
       s0 = s1;
+
+      return s0;
+    }
+
+    function peg$parseportIndex() {
+      var s0, s1, s2, s3;
+
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 91) {
+        s1 = peg$c54;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        if (peg$c56.test(input.charAt(peg$currPos))) {
+          s3 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        }
+        if (s3 !== peg$FAILED) {
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            if (peg$c56.test(input.charAt(peg$currPos))) {
+              s3 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c57); }
+            }
+          }
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 93) {
+            s3 = peg$c58;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c59); }
+          }
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c60(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
 
       return s0;
     }
@@ -1416,12 +1516,12 @@ module.exports = (function() {
     function peg$parseanychar() {
       var s0;
 
-      if (peg$c60.test(input.charAt(peg$currPos))) {
+      if (peg$c61.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c62); }
       }
 
       return s0;
@@ -1431,24 +1531,24 @@ module.exports = (function() {
       var s0, s1, s2;
 
       s0 = peg$currPos;
-      if (peg$c62.test(input.charAt(peg$currPos))) {
+      if (peg$c63.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c63); }
+        if (peg$silentFails === 0) { peg$fail(peg$c64); }
       }
       if (s1 !== peg$FAILED) {
-        if (peg$c64.test(input.charAt(peg$currPos))) {
+        if (peg$c65.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c66); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c66();
+          s1 = peg$c67();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1459,12 +1559,12 @@ module.exports = (function() {
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
-        if (peg$c67.test(input.charAt(peg$currPos))) {
+        if (peg$c68.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c68); }
+          if (peg$silentFails === 0) { peg$fail(peg$c69); }
         }
       }
 
@@ -1476,20 +1576,20 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c69;
+        s1 = peg$c70;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c70); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
         if (input.charCodeAt(peg$currPos) === 32) {
-          s1 = peg$c69;
+          s1 = peg$c70;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          if (peg$silentFails === 0) { peg$fail(peg$c71); }
         }
       }
       if (s0 === peg$FAILED) {
@@ -1504,21 +1604,21 @@ module.exports = (function() {
 
       s0 = [];
       if (input.charCodeAt(peg$currPos) === 32) {
-        s1 = peg$c69;
+        s1 = peg$c70;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c70); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
           if (input.charCodeAt(peg$currPos) === 32) {
-            s1 = peg$c69;
+            s1 = peg$c70;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c70); }
+            if (peg$silentFails === 0) { peg$fail(peg$c71); }
           }
         }
       } else {
@@ -1539,7 +1639,7 @@ module.exports = (function() {
           s3 = peg$parsews();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c71(s2);
+            s1 = peg$c72(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1564,11 +1664,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c49;
+          s2 = peg$c54;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c50); }
+          if (peg$silentFails === 0) { peg$fail(peg$c55); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1598,11 +1698,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c72;
+          s2 = peg$c73;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c73); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1632,11 +1732,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s2 = peg$c53;
+          s2 = peg$c58;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1666,11 +1766,11 @@ module.exports = (function() {
       s1 = peg$parsews();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 125) {
-          s2 = peg$c74;
+          s2 = peg$c75;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c75); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parsews();
@@ -1766,27 +1866,27 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c77.test(input.charAt(peg$currPos))) {
+      if (peg$c78.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        if (peg$silentFails === 0) { peg$fail(peg$c79); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c77.test(input.charAt(peg$currPos))) {
+        if (peg$c78.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c79); }
         }
       }
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
 
       return s0;
@@ -1822,16 +1922,16 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c79) {
-        s1 = peg$c79;
+      if (input.substr(peg$currPos, 5) === peg$c80) {
+        s1 = peg$c80;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+        if (peg$silentFails === 0) { peg$fail(peg$c81); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c81();
+        s1 = peg$c82();
       }
       s0 = s1;
 
@@ -1842,16 +1942,16 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c82) {
-        s1 = peg$c82;
+      if (input.substr(peg$currPos, 4) === peg$c83) {
+        s1 = peg$c83;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c83); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c84();
+        s1 = peg$c85();
       }
       s0 = s1;
 
@@ -1862,16 +1962,16 @@ module.exports = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c85) {
-        s1 = peg$c85;
+      if (input.substr(peg$currPos, 4) === peg$c86) {
+        s1 = peg$c86;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c87();
+        s1 = peg$c88();
       }
       s0 = s1;
 
@@ -1894,7 +1994,7 @@ module.exports = (function() {
             s7 = peg$parsemember();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s5;
-              s6 = peg$c88(s3, s7);
+              s6 = peg$c89(s3, s7);
               s5 = s6;
             } else {
               peg$currPos = s5;
@@ -1912,7 +2012,7 @@ module.exports = (function() {
               s7 = peg$parsemember();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c88(s3, s7);
+                s6 = peg$c89(s3, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -1925,7 +2025,7 @@ module.exports = (function() {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c89(s3, s4);
+            s3 = peg$c90(s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1942,7 +2042,7 @@ module.exports = (function() {
           s3 = peg$parseend_object();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c90(s2);
+            s1 = peg$c91(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1971,7 +2071,7 @@ module.exports = (function() {
           s3 = peg$parsevalue();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c91(s1, s3);
+            s1 = peg$c92(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2005,7 +2105,7 @@ module.exports = (function() {
             s7 = peg$parsevalue();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s5;
-              s6 = peg$c92(s3, s7);
+              s6 = peg$c93(s3, s7);
               s5 = s6;
             } else {
               peg$currPos = s5;
@@ -2023,7 +2123,7 @@ module.exports = (function() {
               s7 = peg$parsevalue();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s5;
-                s6 = peg$c92(s3, s7);
+                s6 = peg$c93(s3, s7);
                 s5 = s6;
               } else {
                 peg$currPos = s5;
@@ -2036,7 +2136,7 @@ module.exports = (function() {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c93(s3, s4);
+            s3 = peg$c94(s3, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2053,7 +2153,7 @@ module.exports = (function() {
           s3 = peg$parseend_array();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c94(s2);
+            s1 = peg$c95(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2094,7 +2194,7 @@ module.exports = (function() {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c96();
+              s1 = peg$c97();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2115,7 +2215,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c95); }
+        if (peg$silentFails === 0) { peg$fail(peg$c96); }
       }
 
       return s0;
@@ -2138,12 +2238,12 @@ module.exports = (function() {
     function peg$parsedigit1_9() {
       var s0;
 
-      if (peg$c97.test(input.charAt(peg$currPos))) {
+      if (peg$c98.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c98); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
 
       return s0;
@@ -2152,12 +2252,12 @@ module.exports = (function() {
     function peg$parsee() {
       var s0;
 
-      if (peg$c99.test(input.charAt(peg$currPos))) {
+      if (peg$c100.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
 
       return s0;
@@ -2271,11 +2371,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c101;
+        s0 = peg$c102;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c103); }
       }
 
       return s0;
@@ -2285,11 +2385,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 43) {
-        s0 = peg$c103;
+        s0 = peg$c104;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c104); }
+        if (peg$silentFails === 0) { peg$fail(peg$c105); }
       }
 
       return s0;
@@ -2299,11 +2399,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 48) {
-        s0 = peg$c105;
+        s0 = peg$c106;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c106); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
 
       return s0;
@@ -2326,7 +2426,7 @@ module.exports = (function() {
           s3 = peg$parsequotation_mark();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c108(s2);
+            s1 = peg$c109(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2343,7 +2443,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c108); }
       }
 
       return s0;
@@ -2358,106 +2458,106 @@ module.exports = (function() {
         s1 = peg$parseescape();
         if (s1 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 34) {
-            s2 = peg$c109;
+            s2 = peg$c110;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c111); }
           }
           if (s2 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 92) {
-              s2 = peg$c111;
+              s2 = peg$c112;
               peg$currPos++;
             } else {
               s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c112); }
+              if (peg$silentFails === 0) { peg$fail(peg$c113); }
             }
             if (s2 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 47) {
-                s2 = peg$c113;
+                s2 = peg$c114;
                 peg$currPos++;
               } else {
                 s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                if (peg$silentFails === 0) { peg$fail(peg$c115); }
               }
               if (s2 === peg$FAILED) {
                 s2 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 98) {
-                  s3 = peg$c115;
+                  s3 = peg$c116;
                   peg$currPos++;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c116); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c117); }
                 }
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s2;
-                  s3 = peg$c117();
+                  s3 = peg$c118();
                 }
                 s2 = s3;
                 if (s2 === peg$FAILED) {
                   s2 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 102) {
-                    s3 = peg$c118;
+                    s3 = peg$c119;
                     peg$currPos++;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c119); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c120); }
                   }
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s2;
-                    s3 = peg$c120();
+                    s3 = peg$c121();
                   }
                   s2 = s3;
                   if (s2 === peg$FAILED) {
                     s2 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 110) {
-                      s3 = peg$c121;
+                      s3 = peg$c122;
                       peg$currPos++;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c122); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c123); }
                     }
                     if (s3 !== peg$FAILED) {
                       peg$savedPos = s2;
-                      s3 = peg$c123();
+                      s3 = peg$c124();
                     }
                     s2 = s3;
                     if (s2 === peg$FAILED) {
                       s2 = peg$currPos;
                       if (input.charCodeAt(peg$currPos) === 114) {
-                        s3 = peg$c124;
+                        s3 = peg$c125;
                         peg$currPos++;
                       } else {
                         s3 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c125); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c126); }
                       }
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s2;
-                        s3 = peg$c126();
+                        s3 = peg$c127();
                       }
                       s2 = s3;
                       if (s2 === peg$FAILED) {
                         s2 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 116) {
-                          s3 = peg$c127;
+                          s3 = peg$c128;
                           peg$currPos++;
                         } else {
                           s3 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c128); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c129); }
                         }
                         if (s3 !== peg$FAILED) {
                           peg$savedPos = s2;
-                          s3 = peg$c129();
+                          s3 = peg$c130();
                         }
                         s2 = s3;
                         if (s2 === peg$FAILED) {
                           s2 = peg$currPos;
                           if (input.charCodeAt(peg$currPos) === 117) {
-                            s3 = peg$c130;
+                            s3 = peg$c131;
                             peg$currPos++;
                           } else {
                             s3 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c131); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c132); }
                           }
                           if (s3 !== peg$FAILED) {
                             s4 = peg$currPos;
@@ -2495,7 +2595,7 @@ module.exports = (function() {
                             }
                             if (s4 !== peg$FAILED) {
                               peg$savedPos = s2;
-                              s3 = peg$c132(s4);
+                              s3 = peg$c133(s4);
                               s2 = s3;
                             } else {
                               peg$currPos = s2;
@@ -2515,7 +2615,7 @@ module.exports = (function() {
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c133(s2);
+            s1 = peg$c134(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2534,11 +2634,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 92) {
-        s0 = peg$c111;
+        s0 = peg$c112;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c112); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
 
       return s0;
@@ -2548,11 +2648,11 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c109;
+        s0 = peg$c110;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c110); }
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
       }
 
       return s0;
@@ -2561,12 +2661,12 @@ module.exports = (function() {
     function peg$parseunescaped() {
       var s0;
 
-      if (peg$c134.test(input.charAt(peg$currPos))) {
+      if (peg$c135.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c135); }
+        if (peg$silentFails === 0) { peg$fail(peg$c136); }
       }
 
       return s0;
@@ -2575,12 +2675,12 @@ module.exports = (function() {
     function peg$parseDIGIT() {
       var s0;
 
-      if (peg$c51.test(input.charAt(peg$currPos))) {
+      if (peg$c56.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c52); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
 
       return s0;
@@ -2589,12 +2689,12 @@ module.exports = (function() {
     function peg$parseHEXDIG() {
       var s0;
 
-      if (peg$c136.test(input.charAt(peg$currPos))) {
+      if (peg$c137.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c137); }
+        if (peg$silentFails === 0) { peg$fail(peg$c138); }
       }
 
       return s0;
@@ -2742,14 +2842,14 @@ module.exports = (function() {
         flats = flatten(parser.edges);
         grouped = [];
         var current = {};
-        flats.forEach(function (o, i) {
-          if (i % 2 !== 0) {
-            var pair = grouped[grouped.length - 1];
-            pair.tgt = o.tgt;
-            return;
-          }
-          grouped.push(o);
-        });
+        for (var i = 1; i < flats.length; i += 1) {
+            // skip over default ports at the beginning of lines (could also handle this in grammar)
+            if (("src" in flats[i - 1] || "data" in flats[i - 1]) && "tgt" in flats[i]) {
+                flats[i - 1].tgt = flats[i].tgt;
+                grouped.push(flats[i - 1]);
+                i++;
+            }
+        }
         return grouped;
       }
 

--- a/spec/fbp.coffee
+++ b/spec/fbp.coffee
@@ -62,6 +62,14 @@ describe 'FBP parser', ->
       graphData = parser.parse fbpData, caseSensitive:true
       chai.expect(graphData.connections).to.have.length 3
 
+  describe 'with no spaces around arrows', ->
+    it 'should not fail', ->
+      fbpData = """
+      a(A)->b(B) ->c(C)-> d(D)->e
+      """
+      graphData = parser.parse fbpData, caseSensitive:true
+      chai.expect(graphData.connections).to.have.length 4
+
   describe 'with anonymous nodes in an FBP string', ->
     fbpData = """
     (A) OUT -> IN (B) OUT -> IN (B)

--- a/spec/fbp.coffee
+++ b/spec/fbp.coffee
@@ -26,7 +26,7 @@ describe 'FBP parser', ->
         chai.expect(graphData.connections.length).to.equal 1
         chai.expect(graphData.connections[0]).to.eql
           data: 'somefile'
-          tgt: 
+          tgt:
             process: 'Read'
             port: 'SOURCE'
 
@@ -136,6 +136,28 @@ describe 'FBP parser', ->
         chai.expect(graphData.inports).to.be.an 'undefined'
         chai.expect(graphData.outports).to.be.an 'undefined'
 
+  describe 'with FBP string containing a JSON IIP string', ->
+    fbpData = """
+    { "string": "s", "number": 123, "array": [1,2,3], "object": {}} -> IN Display(Output)
+    """
+    graphData = null
+    it 'should produce a graph JSON object', ->
+      graphData = parser.parse fbpData, caseSensitive:true
+      chai.expect(graphData).to.be.an 'object'
+    describe 'the generated graph', ->
+      it 'should contain a node', ->
+        chai.expect(graphData.processes).to.eql
+          Display:
+            component: 'Output'
+      it 'should contain an IIP', ->
+        chai.expect(graphData.connections).to.be.an 'array'
+        chai.expect(graphData.connections.length).to.equal 1
+        chai.expect(graphData.connections[0].data).to.deep.equal { "string": "s", "number": 123, "array": [1,2,3], "object": {}}
+      it 'should contain no exports', ->
+        chai.expect(graphData.exports).to.be.an 'undefined'
+        chai.expect(graphData.inports).to.be.an 'undefined'
+        chai.expect(graphData.outports).to.be.an 'undefined'
+
   describe 'with FBP string containing comments', ->
     fbpData = """
     # Do stuff
@@ -216,7 +238,7 @@ describe 'FBP parser', ->
     INPORT=Read.IN:FILENAME
     INPORT=Display.OPTIONS:OPTIONS
     OUTPORT=Display.OUT:OUT
-    Read(ReadFile) OUT -> IN Display(Output) 
+    Read(ReadFile) OUT -> IN Display(Output)
     """
     graphData = null
     it 'should produce a graph JSON object', ->
@@ -258,7 +280,7 @@ describe 'FBP parser', ->
   describe 'with FBP string with legacy EXPORTs', ->
     fbpData = """
     EXPORT=Read.IN:FILENAME
-    Read(ReadFile) OUT -> IN Display(Output) 
+    Read(ReadFile) OUT -> IN Display(Output)
     """
     graphData = null
     it 'should produce a graph JSON object', ->
@@ -291,7 +313,7 @@ describe 'FBP parser', ->
   describe 'with FBP string containing node metadata', ->
     fbpData = """
     Read(ReadFile) OUT -> IN Display(Output:foo=bar)
-    
+
     # And we drop the rest
     Display OUT -> IN Drop(Drop:foo=baz,baz=/foo/bar)
     """
@@ -438,7 +460,7 @@ describe 'FBP parser', ->
   describe 'with FBP string containing port indexes', ->
     fbpData = """
     Read(ReadFile) OUT[1] -> IN Display(Output:foo=bar)
-    
+
     # And we drop the rest
     Display OUT -> IN[0] Drop(Drop:foo=baz,baz=/foo/bar)
     """
@@ -590,4 +612,3 @@ describe 'FBP parser', ->
       chai.expect(graphData.exports[0]).to.eql
         private: 'read.in'
         public: 'filename'
-

--- a/spec/fbp.coffee
+++ b/spec/fbp.coffee
@@ -62,6 +62,33 @@ describe 'FBP parser', ->
       graphData = parser.parse fbpData, caseSensitive:true
       chai.expect(graphData.connections).to.have.length 3
 
+  describe 'with anonymous nodes in an FBP string', ->
+    fbpData = """
+    (A) OUT -> IN (B) OUT -> IN (B)
+    """
+    graphData = null
+    it 'should produce a graph JSON object', ->
+      graphData = parser.parse fbpData, caseSensitive:true
+      chai.expect(graphData).to.be.an 'object'
+    describe 'the generated graph', ->
+      it 'should contain three nodes with unique names', ->
+        chai.expect(graphData.processes).to.eql
+          _A_1:
+            component: 'A'
+          _B_1:
+            component: 'B'
+          _B_2:
+            component: 'B'
+      it 'should contain two edges', ->
+        chai.expect(graphData.connections).to.eql [
+          { src: { process: '_A_1', port: 'OUT' }, tgt: { process: '_B_1', port: 'IN' } }
+          { src: { process: '_B_1', port: 'OUT' }, tgt: { process: '_B_2', port: 'IN' } }
+        ]
+      it 'should contain no exports', ->
+        chai.expect(graphData.exports).to.be.an 'undefined'
+        chai.expect(graphData.inports).to.be.an 'undefined'
+        chai.expect(graphData.outports).to.be.an 'undefined'
+
   describe 'with a more complex FBP string', ->
     fbpData = """
     '8003' -> LISTEN WebServer(HTTP/Server) REQUEST -> IN Profiler(HTTP/Profiler) OUT -> IN Authentication(HTTP/BasicAuth)

--- a/spec/fbp.coffee
+++ b/spec/fbp.coffee
@@ -89,6 +89,61 @@ describe 'FBP parser', ->
         chai.expect(graphData.inports).to.be.an 'undefined'
         chai.expect(graphData.outports).to.be.an 'undefined'
 
+  describe 'with default inport', ->
+    fbpData = """
+    (A) OUT -> (B)
+    """
+    graphData = null
+    it 'should produce a graph JSON object', ->
+      graphData = parser.parse fbpData, caseSensitive:true
+      chai.expect(graphData).to.be.an 'object'
+    describe 'the generated graph', ->
+      it 'should default port name to "IN"', ->
+        chai.expect(graphData.connections).to.eql [
+          { src: { process: '_A_1', port: 'OUT' }, tgt: { process: '_B_1', port: 'IN' } }
+        ]
+      it 'should contain no exports', ->
+        chai.expect(graphData.exports).to.be.an 'undefined'
+        chai.expect(graphData.inports).to.be.an 'undefined'
+        chai.expect(graphData.outports).to.be.an 'undefined'
+
+  describe 'with default outport', ->
+    fbpData = """
+    (A) -> IN (B)
+    """
+    graphData = null
+    it 'should produce a graph JSON object', ->
+      graphData = parser.parse fbpData, caseSensitive:true
+      chai.expect(graphData).to.be.an 'object'
+    describe 'the generated graph', ->
+      it 'should default port name to "OUT"', ->
+        chai.expect(graphData.connections).to.eql [
+          { src: { process: '_A_1', port: 'OUT' }, tgt: { process: '_B_1', port: 'IN' } }
+        ]
+      it 'should contain no exports', ->
+        chai.expect(graphData.exports).to.be.an 'undefined'
+        chai.expect(graphData.inports).to.be.an 'undefined'
+        chai.expect(graphData.outports).to.be.an 'undefined'
+
+  describe 'with default ports', ->
+    fbpData = """
+    (A) -> (B) -> (C)
+    """
+    graphData = null
+    it 'should produce a graph JSON object', ->
+      graphData = parser.parse fbpData, caseSensitive:true
+      chai.expect(graphData).to.be.an 'object'
+    describe 'the generated graph', ->
+      it 'should correctly use default ports', ->
+        chai.expect(graphData.connections).to.eql [
+          { src: { process: '_A_1', port: 'OUT' }, tgt: { process: '_B_1', port: 'IN' } }
+          { src: { process: '_B_1', port: 'OUT' }, tgt: { process: '_C_1', port: 'IN' } }
+        ]
+      it 'should contain no exports', ->
+        chai.expect(graphData.exports).to.be.an 'undefined'
+        chai.expect(graphData.inports).to.be.an 'undefined'
+        chai.expect(graphData.outports).to.be.an 'undefined'
+
   describe 'with a more complex FBP string', ->
     fbpData = """
     '8003' -> LISTEN WebServer(HTTP/Server) REQUEST -> IN Profiler(HTTP/Profiler) OUT -> IN Authentication(HTTP/BasicAuth)
@@ -390,7 +445,7 @@ describe 'FBP parser', ->
 
   describe 'with an invalid FBP string', ->
     fbpData = """
-    'foo' -> Display(Output)
+    'foo' --> Display(Output)
     """
     it 'should fail with an Exception', ->
       chai.expect(-> parser.parse fbpData, caseSensitive:true).to.throw Error


### PR DESCRIPTION
This PR does a bunch of things. I can try to split them up into multiple PRs but I'd rather not because some of them are interdependent.

* Allow sending other valid JSON types as IIPs #10
* Allow anonymous nodes #11
* Declare components before connecting them. #12
* Parser seems to need blanks around the arrows. #21
* default ports #32

You can now write incredibly succinct networks, e.x.

```
(stdin) -> (uppercase) -> (stdout)
```

**Allow sending other valid JSON types as IIPs**

Resolves #10

You can now do things like:

```
1234 -> IN Display(Output)
"foo" -> IN Display(Output)
[1,2,3,4] -> IN Display(Output)
{ "foo": "bar" } -> IN Display(Output)
{ "foo": { "bar": { "baz": 1234 }}} -> IN Display(Output)
```

`true`, `false`, and `null` don't work because they are valid node names.

I'm just using the JSON grammar straight from peg.js' example directory.

**Allow anonymous nodes**

Resolves #11

Nodes without a name are supported. Internally they are given a unique name based on the component name and index to help debugging.

```
'foo' -> IN (Output)
```

The `Output` component is internally named `_output_1`.

**Declare components before connecting them**

Resolves #12

Lets you declare a component without connecting it immediately:

```
Display(Output)
'foo' -> Display
```

**Parser seems to need blanks around the arrows.**

Resolves #21

You can now do 

```
(A)->(B)
```

**Default Ports**

Resolves #32

The port name can be left off in which case it will default to "IN" or "OUT". The following are equivalent:

```
(A) -> (B)
(A) OUT -> IN (B)
(A) OUT -> (B)
(A) -> IN (B)
```

In certain causes this is not allowed due to ambiguity, e.x. 

```(A) OUT -> X Y -> (C)```

Is X the inport and Y the component, or is X the component and Y the outport?
